### PR TITLE
YTDB-190: Fixes and improvements for unionAll, intersect and difference

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/executor/FuncitonAggregationContext.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/executor/FuncitonAggregationContext.java
@@ -34,6 +34,7 @@ public class FuncitonAggregationContext implements AggregationContext {
     for (SQLExpression expr : params) {
       paramValues.add(expr.execute(next, ctx));
     }
+    ctx.setVariable("aggregation", true);
     aggregateFunction.execute(next, null, null, paramValues.toArray(), ctx);
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
@@ -19,10 +19,10 @@
  */
 package com.jetbrains.youtrack.db.internal.core.sql.functions.coll;
 
-import com.jetbrains.youtrack.db.internal.core.command.CommandContext;
 import com.jetbrains.youtrack.db.api.DatabaseSession;
 import com.jetbrains.youtrack.db.api.record.Identifiable;
-import java.util.Collection;
+import com.jetbrains.youtrack.db.internal.common.collection.MultiValue;
+import com.jetbrains.youtrack.db.internal.core.command.CommandContext;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -35,7 +35,7 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
   public static final String NAME = "difference";
 
   public SQLFunctionDifference() {
-    super(NAME, 2, -1);
+    super(NAME, 1, -1);
   }
 
   @SuppressWarnings("unchecked")
@@ -45,36 +45,42 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
       Object iCurrentResult,
       final Object[] iParams,
       CommandContext iContext) {
+
+    if (Boolean.TRUE.equals(iContext.getVariable("aggregation"))) {
+      return null; // or throw error? we don't support aggregation mode here
+    }
+
     if (iParams[0] == null) {
-      return null;
+      return Set.of();
     }
 
     // IN-LINE MODE (STATELESS)
     final Set<Object> result = new HashSet<Object>();
 
-    boolean first = true;
-    for (Object iParameter : iParams) {
-      if (first) {
-        if (iParameter instanceof Collection<?>) {
-          result.addAll((Collection<Object>) iParameter);
-        } else {
-          result.add(iParameter);
-        }
-      } else {
-        if (iParameter instanceof Collection<?>) {
-          result.removeAll((Collection<Object>) iParameter);
-        } else {
-          result.remove(iParameter);
-        }
+    final var firstIt = MultiValue.getMultiValueIterator(iParams[0]);
+    while (firstIt.hasNext()) {
+      result.add(firstIt.next());
+    }
+
+    if (result.isEmpty()) { // no need to iterate further
+      return Set.of();
+    }
+
+    for (int i = 1; i < iParams.length; i++) {
+      if (iParams[i] == null) {
+        continue;
       }
 
-      first = false;
+      final var it = MultiValue.getMultiValueIterator(iParams[i]);
+      while (it.hasNext()) {
+        result.remove(it.next());
+      }
     }
 
     return result;
   }
 
   public String getSyntax(DatabaseSession session) {
-    return "difference(<field>, <field> [, <field]*)";
+    return "difference(<field> [, <field]*)";
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
@@ -20,6 +20,7 @@
 package com.jetbrains.youtrack.db.internal.core.sql.functions.coll;
 
 import com.jetbrains.youtrack.db.api.DatabaseSession;
+import com.jetbrains.youtrack.db.api.exception.CommandExecutionException;
 import com.jetbrains.youtrack.db.api.record.Identifiable;
 import com.jetbrains.youtrack.db.internal.common.collection.MultiValue;
 import com.jetbrains.youtrack.db.internal.core.command.CommandContext;
@@ -47,9 +48,10 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
       CommandContext iContext) {
 
     if (Boolean.TRUE.equals(iContext.getVariable("aggregation"))) {
-      return null; // or throw error? we don't support aggregation mode here
+      throw new CommandExecutionException("difference function cannot be used in aggregation mode");
     }
 
+    // if the first parameter is null, then the overall result is empty
     if (iParams[0] == null) {
       return Set.of();
     }
@@ -67,6 +69,7 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
     }
 
     for (int i = 1; i < iParams.length; i++) {
+      // if the parameter is null, ignoring it, it will not affect the difference result
       if (iParams[i] == null) {
         continue;
       }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionIntersect.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionIntersect.java
@@ -62,7 +62,7 @@ public class SQLFunctionIntersect extends SQLFunctionMultiValueAbstract<Object> 
       return Collections.emptySet();
     }
 
-    if (iParams.length == 1) {
+    if (Boolean.TRUE.equals(iContext.getVariable("aggregation"))) {
       // AGGREGATION MODE (STATEFUL)
       if (context == null) {
         // ADD ALL THE ITEMS OF THE FIRST COLLECTION

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionUnionAll.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionUnionAll.java
@@ -49,7 +49,7 @@ public class SQLFunctionUnionAll extends SQLFunctionMultiValueAbstract<Collectio
       final Object iCurrentResult,
       final Object[] iParams,
       CommandContext iContext) {
-    if (iParams.length == 1) {
+    if (Boolean.TRUE.equals(iContext.getVariable("aggregation"))) {
       // AGGREGATION MODE (STATEFUL)
       Object value = iParams[0];
       if (value != null) {

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/parser/SQLFunctionCall.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/parser/SQLFunctionCall.java
@@ -146,6 +146,7 @@ public class SQLFunctionCall extends SimpleNode {
 
       validateFunctionParams(ctx.getDatabase(), function, paramValues);
 
+      ctx.setVariable("aggregation", false);
       if (record instanceof Identifiable) {
         return function.execute(
             targetObjects, (Identifiable) record, null, paramValues.toArray(), ctx);

--- a/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLCombinationFunctionTests.java
+++ b/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLCombinationFunctionTests.java
@@ -3,6 +3,7 @@ package com.jetbrains.youtrack.db.auto;
 import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Sets;
+import com.jetbrains.youtrack.db.api.exception.CommandExecutionException;
 import com.jetbrains.youtrack.db.api.query.Result;
 import com.jetbrains.youtrack.db.api.record.Entity;
 import com.jetbrains.youtrack.db.api.record.Identifiable;
@@ -64,6 +65,16 @@ public class SQLCombinationFunctionTests extends BaseDBTest {
 
     // comparing sorted lists to ignore any differences in order
     assertListsEqualsIgnoreOrder(continentsCombined, continents);
+  }
+
+  @Test
+  public void differenceAsAggregationThrowsError() {
+    try {
+      database.query("SELECT difference(continent) AS continents FROM CountryExt").toList();
+      Assert.fail("Expected exception");
+    } catch (CommandExecutionException e) {
+      Assert.assertTrue(e.getMessage().contains("cannot be used in aggregation mode"));
+    }
   }
 
   @Test

--- a/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLCombinationFunctionTests.java
+++ b/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLCombinationFunctionTests.java
@@ -1,0 +1,505 @@
+package com.jetbrains.youtrack.db.auto;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.Sets;
+import com.jetbrains.youtrack.db.api.query.Result;
+import com.jetbrains.youtrack.db.api.record.Entity;
+import com.jetbrains.youtrack.db.api.record.Identifiable;
+import com.jetbrains.youtrack.db.api.record.Vertex;
+import com.jetbrains.youtrack.db.api.schema.PropertyType;
+import com.jetbrains.youtrack.db.api.schema.SchemaClass;
+import com.jetbrains.youtrack.db.internal.common.util.RawPair;
+import com.jetbrains.youtrack.db.internal.core.db.record.ridbag.RidBag;
+import com.jetbrains.youtrack.db.internal.core.id.RecordId;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for "unionAll", "intersect" and "difference" functions.
+ */
+@Test
+public class SQLCombinationFunctionTests extends BaseDBTest {
+
+  @Parameters(value = "remote")
+  public SQLCombinationFunctionTests(@Optional Boolean remote) {
+    super(remote != null && remote);
+  }
+
+  @BeforeClass
+  @Override
+  public void beforeClass() throws Exception {
+    super.beforeClass();
+
+    generateGraphRandomData();
+    generateGeoData();
+  }
+
+
+  @Test
+  public void unionAllAsAggregationNotRemoveDuplicates() {
+
+    final var continents = database.query("SELECT continent FROM CountryExt").toList()
+        .stream()
+        .map(r -> r.<String>getProperty("continent"))
+        .toList();
+
+    final var continentsCombined =
+        database.query("SELECT unionAll(continent) AS continents FROM CountryExt").toList()
+            .getFirst()
+            .<List<String>>getProperty("continents");
+
+    // comparing sorted lists to ignore any differences in order
+    assertListsEqualsIgnoreOrder(continentsCombined, continents);
+  }
+
+  @Test
+  public void unionAllLanguagesByCountry() {
+    findLanguagesForCountry(FunctionDefinition.UNION_ALL);
+  }
+
+  @Test
+  public void intersectLanguagesByCountry() {
+    findLanguagesForCountry(FunctionDefinition.INTERSECT);
+  }
+
+  @Test
+  public void differenceLanguagesByCountry() {
+    findLanguagesForCountry(FunctionDefinition.DIFFERENCE);
+  }
+
+  // This test loads languages for specific countries and combines them using the specified function.
+  // The loading of the languages is done in both aggregation and inline/scalar modes:
+  // Aggregation:
+  //    SELECT unionAll(languages) FROM CountryExt WHERE name = 'France' OR name = 'Germany'
+  // Inline:
+  //    SELECT $r AS langCombined LET
+  //       $l0 = (SELECT expand(languages) FROM CountryExt WHERE name = 'France'),
+  //       $l1 = (SELECT expand(languages) FROM CountryExt WHERE name = 'Germany'),
+  //       $r = unionAll($l0, $l1)
+  private void findLanguagesForCountry(FunctionDefinition fDef) {
+
+    final var langsByCountry = database.query("select name, languages from CountryExt").toList()
+        .stream()
+        .collect(Collectors.toMap(
+            r -> r.<String>getProperty("name"),
+            r -> r.<List<String>>getProperty("languages")
+        ));
+
+    final var countrySets =
+        combinations(fDef.minFunctionArgs, langsByCountry.size(), langsByCountry.keySet());
+
+    for (Set<String> countrySet : countrySets) {
+
+      // This is the expected result, that must be produced by both queries below
+      final var expectedLangs =
+          fDef.impl(countrySet.stream().map(langsByCountry::get).toList());
+
+      if (fDef.aggregationMode) {
+        // 1. Aggregation mode
+        // Example:
+        // SELECT unionAll(languages) FROM CountryExt WHERE name = 'France'
+        final var query1 = new StringBuilder("SELECT ")
+            .append(fDef.name).append("(languages) AS langCombined FROM CountryExt WHERE ");
+
+        // can't use IN operator because of https://youtrack.jetbrains.com/issue/YTDB-227
+        final var countryConditions =
+            countrySet.stream()
+                .map(s -> String.format("(name = '%s')", s))
+                .toList();
+
+        query1.append(String.join(" OR ", countryConditions));
+        final var l1 = database.query(query1.toString()).toList()
+            .getFirst()
+            .<Collection<String>>getProperty("langCombined");
+
+        final var langsCombined1 = l1.stream().toList();
+
+        assertListsEqualsIgnoreOrder(langsCombined1, expectedLangs);
+      }
+
+      // 2. Inline mode
+      // Example:
+      // SELECT $r AS langCombined LET
+      //   $l0 = (SELECT expand(languages) FROM CountryExt WHERE name = 'France'),
+      //   $l1 = (SELECT expand(languages) FROM CountryExt WHERE name = 'Germany'),
+      //   $r = unionAll($l0, $l1)
+      final var query2 = new StringBuilder("SELECT $r AS langCombined LET ");
+
+      final var lVars = new ArrayList<String>();
+      final var countryList = countrySet.stream().toList();
+      for (int i = 0; i < countrySet.size(); i++) {
+        query2.append(String.format(
+            "$l%d = (SELECT expand(languages) FROM CountryExt WHERE name = '%s'),",
+            i, countryList.get(i)
+        ));
+        lVars.add(String.format("$l%d", i));
+      }
+      query2
+          .append("$r = ").append(fDef.name).append("(")
+          .append(String.join(",", lVars))
+          .append(")");
+
+      final var langsCombined2 = database.query(query2.toString()).toList().getFirst()
+          .<Collection<Result>>getProperty("langCombined")
+          .stream()
+          .map(e -> e.<String>getProperty("value"))
+          .collect(Collectors.toList());
+
+      assertListsEqualsIgnoreOrder(langsCombined2, expectedLangs);
+    }
+  }
+
+  @Test
+  public void unionAllCountriesByLanguage() {
+    findCountriesForLanguage(FunctionDefinition.UNION_ALL);
+  }
+
+  @Test
+  public void intersectCountriesByLanguage() {
+    findCountriesForLanguage(FunctionDefinition.INTERSECT);
+  }
+
+  @Test
+  public void differenceCountriesByLanguage() {
+    findCountriesForLanguage(FunctionDefinition.DIFFERENCE);
+  }
+
+  // This test loads country records for specific languages (inline/scalar mode only):
+  // SELECT expand($r) AS countries LET
+  //      $l1 = (SELECT FROM CountryExt WHERE 'French' IN languages),
+  //      $l2 = (SELECT FROM CountryExt WHERE 'German' IN languages),
+  //      $r = unionAll($l1, $l2)
+
+  private void findCountriesForLanguage(FunctionDefinition fDef) {
+
+    final var countryByLang =
+        database.query("select name, languages from CountryExt").toList()
+            .stream()
+            .collect(Collectors.toMap(
+                r1 -> r1.<String>getProperty("name"),
+                r1 -> r1.<List<String>>getProperty("languages")
+            ))
+            .entrySet().stream()
+            .flatMap(e -> e.getValue().stream().map(l -> new RawPair<>(l, e.getKey())))
+            .collect(Collectors.groupingBy(
+                RawPair::getFirst,
+                Collectors.mapping(RawPair::getSecond, Collectors.toList())
+            ));
+
+    final var langCombinations = combinations(fDef.minFunctionArgs, countryByLang.size(),
+        countryByLang.keySet());
+
+    for (Set<String> langCombination : langCombinations) {
+      final StringBuilder query = new StringBuilder("SELECT expand($r2) LET ");
+
+      final var langsList = langCombination.stream().toList();
+      final var varNames = new ArrayList<String>();
+      for (int i = 0; i < langsList.size(); i++) {
+        query.append(
+            String.format("$l%d = (SELECT FROM CountryExt WHERE '%s' IN languages),",
+                i, langsList.get(i))
+        );
+        varNames.add(String.format("$l%d", i));
+      }
+
+      query.append(String.format("$r = %s(%s),", fDef.name, String.join(",", varNames)));
+      query.append("$r2 = (SELECT from $r)");
+
+      final var selectedCountryNames = database.query(query.toString())
+          .stream()
+          .map(r -> r.<String>getProperty("name"))
+          .toList();
+
+      final var expectedCountryNames = fDef.impl(
+          langsList.stream().map(countryByLang::get).toList()
+      );
+
+      assertListsEqualsIgnoreOrder(selectedCountryNames, expectedCountryNames);
+
+    }
+  }
+
+  @Test
+  public void unionAllInlineEdges() {
+    runEdgeInlineTest(FunctionDefinition.UNION_ALL);
+  }
+
+  @Test
+  public void intersectInlineEdges() {
+    runEdgeInlineTest(FunctionDefinition.INTERSECT);
+  }
+
+  @Test
+  public void differenceInlineEdges() {
+    runEdgeInlineTest(FunctionDefinition.DIFFERENCE);
+  }
+
+  private void runEdgeInlineTest(FunctionDefinition fDef) {
+
+    final var vertexes = database.query("SELECT FROM V").toList();
+
+    final var insAndOuts = vertexes.stream().collect(Collectors.toMap(
+        r -> r.<RecordId>getProperty("@rid"),
+        r -> {
+
+          final var ins = r.<RidBag>getProperty("in_");
+          final var outs = r.<RidBag>getProperty("out_");
+
+          return new RawPair<>(ins, outs);
+        }
+    ));
+
+    final var query = "SELECT @rid, " + fDef.name + "(in_, out_) AS edges FROM V";
+    List<Result> edgesAggregated = database.query(query).stream().toList();
+
+    for (Result d : edgesAggregated) {
+      Assert.assertTrue(d.hasProperty("edges"));
+    }
+
+    final var result = edgesAggregated.stream().collect(Collectors.toMap(
+        r -> r.<RecordId>getProperty("@rid"),
+        r -> r.<Collection<Identifiable>>getProperty("edges")
+    ));
+    assertEquals(insAndOuts.keySet(), result.keySet());
+
+    for (Entry<RecordId, RawPair<RidBag, RidBag>> e : insAndOuts.entrySet()) {
+      final var rid = e.getKey();
+
+      final List<Identifiable> ins =
+          e.getValue().getFirst() == null ? List.of() :
+              StreamSupport.stream(e.getValue().getFirst().spliterator(), false).toList();
+
+      final List<Identifiable> outs =
+          e.getValue().getSecond() == null ? List.of() :
+              StreamSupport.stream(e.getValue().getSecond().spliterator(), false).toList();
+
+      final var expectedEdges = fDef.impl(List.of(ins, outs));
+
+      final var edges = new ArrayList<>(result.get(rid));
+
+      assertListsEqualsIgnoreOrder(edges, expectedEdges);
+    }
+  }
+
+  private void generateGraphRandomData() {
+
+    SchemaClass vehicleClass = database.createVertexClass("GraphVehicle");
+    database.createClass("GraphCar", vehicleClass.getName());
+    database.createClass("GraphMotocycle", "GraphVehicle");
+    final var r = new Random();
+
+    final var carsNo = r.nextInt(2, 32);
+
+    database.begin();
+    final var cars = new ArrayList<Vertex>();
+    for (int i = 0; i < carsNo; i++) {
+      var carNode = database.newVertex("GraphCar");
+      carNode.setProperty("brand", "Brand" + (i + 1));
+      carNode.setProperty("model", "Car" + (i + 1));
+      carNode.setProperty("year", r.nextInt(1990, 2024));
+      carNode.save();
+      cars.add(carNode);
+    }
+
+    final var motorcyclesNo = r.nextInt(2, 32);
+    final var motorcycles = new ArrayList<Vertex>();
+    for (int i = 0; i < motorcyclesNo; i++) {
+      var motorcycleNode = database.newVertex("GraphMotocycle");
+      motorcycleNode.setProperty("brand", "Brand" + (i + 1));
+      motorcycleNode.setProperty("model", "Motorcycle" + (i + 1));
+      motorcycleNode.setProperty("year", r.nextInt(1990, 2024));
+      motorcycleNode.save();
+      motorcycles.add(motorcycleNode);
+    }
+    database.commit();
+
+    // creating random edges between cars and motocycles
+    class EdgeDef {
+
+      final int carIdx;
+      final int monoIdx;
+      final boolean reverse;
+
+      public EdgeDef(int carIdx, int monoIdx, boolean reverse) {
+        this.carIdx = carIdx;
+        this.monoIdx = monoIdx;
+        this.reverse = reverse;
+      }
+    }
+    final var edges = new ArrayList<EdgeDef>();
+    for (int i = 0; i < carsNo; i++) {
+      for (int i1 = 0; i1 < motorcyclesNo; i1++) {
+        for (boolean reverese : new boolean[]{false, true}) {
+          edges.add(new EdgeDef(i, i1, reverese));
+        }
+      }
+    }
+    Collections.shuffle(edges, r);
+    final var edgesToCreate = edges.stream().limit(r.nextInt(2, 32)).toList();
+
+    database.begin();
+    for (EdgeDef re : edgesToCreate) {
+      final var car = cars.get(re.carIdx);
+      final var motorcycle = motorcycles.get(re.monoIdx);
+
+      final Vertex from;
+      final Vertex to;
+      if (re.reverse) {
+        from = database.bindToSession(motorcycle);
+        to = database.bindToSession(car);
+      } else {
+        from = database.bindToSession(car);
+        to = database.bindToSession(motorcycle);
+      }
+      database.newRegularEdge(from, to).save();
+    }
+    database.commit();
+  }
+
+  private void generateGeoData() {
+    var countryClass = database.createClass("CountryExt");
+    countryClass.createProperty(database, "name", PropertyType.STRING);
+    countryClass.createProperty(database, "continent", PropertyType.STRING);
+    countryClass.createProperty(database, "languages", PropertyType.EMBEDDEDLIST,
+        PropertyType.STRING);
+
+    var cls = database.createClass("CityExt");
+    cls.createProperty(database, "name", PropertyType.STRING);
+    cls.createProperty(database, "country", PropertyType.LINK, countryClass);
+
+    database.begin();
+
+    final var germany = createCountry("Germany", "Europe", List.of("German"));
+    final var czech = createCountry("Czech Republic", "Europe", List.of("Czech"));
+    final var switzerland = createCountry("Switzerland", "Europe",
+        List.of("German", "French", "Italian"));
+    final var france = createCountry("France", "Europe", List.of("French"));
+    final var portugal = createCountry("Portugal", "Europe", List.of("Portuguese"));
+    final var china = createCountry("China", "Asia", List.of("Mandarin", "Cantonese"));
+    final var brazil = createCountry("Brazil", "South America", List.of("Portuguese"));
+    final var usa = createCountry("USA", "North America", List.of("English"));
+    final var uk = createCountry("United Kingdom", "Europe", List.of("English", "Welsh"));
+
+    createCity("Berlin", null, germany);
+    createCity("Munich", "München", germany);
+    createCity("Frankfurt", "Frankfurt am Main", germany);
+    createCity("Prague", "Praha", czech);
+    createCity("Paris", null, france);
+    createCity("Lyon", null, france);
+    createCity("Bern", null, switzerland);
+    createCity("Geneva", null, switzerland);
+    createCity("Lisbon", "Lisboa", portugal);
+    createCity("Beijing", null, china);
+    createCity("Shanghai", null, china);
+    createCity("Rio de Janeiro", null, brazil);
+    createCity("San Francisco", null, usa);
+    createCity("Tampa", null, usa);
+    createCity("London", null, uk);
+    createCity("Glasgow", null, uk);
+
+    database.commit();
+  }
+
+  private Entity createCountry(String name, String continent, List<String> languages) {
+
+    var country = database.newInstance("CountryExt");
+    country.setProperty("name", name);
+    country.setProperty("continent", continent);
+    country.setProperty("languages", languages);
+    country.save();
+
+    return country;
+  }
+
+  private Entity createCity(String name, String localName, Entity country) {
+    var city = database.newInstance("CityExt");
+    city.setProperty("name", name);
+    city.setProperty("localName", localName == null ? name : localName);
+    city.setProperty("country", country);
+    city.save();
+
+    return city;
+  }
+
+  private static void assertListsEqualsIgnoreOrder(List<?> list1, List<?> list2) {
+    assertListsEqualsIgnoreOrder(list1, list2, null);
+  }
+
+  private static void assertListsEqualsIgnoreOrder(List<?> list1, List<?> list2, String message) {
+    final var l1Sorted = list1.stream().sorted().toList();
+    final var l2Sorted = list2.stream().sorted().toList();
+    Assert.assertEquals(l1Sorted, l2Sorted, message);
+  }
+
+  private static Set<Set<String>> combinations(int minLength, int maxLength, Set<String> values) {
+
+    final var combinations = new HashSet<Set<String>>();
+    for (int i = minLength; i <= Math.min(maxLength, values.size()); i++) {
+      combinations.addAll(Sets.combinations(values, i));
+    }
+
+    return combinations;
+  }
+
+  private enum FunctionDefinition {
+
+    UNION_ALL("unionAll", true, 1) {
+      @Override
+      public <T> List<T> impl(List<List<T>> collections) {
+        return collections.stream().flatMap(Collection::stream).toList();
+      }
+    },
+    INTERSECT("intersect", true, 1) {
+      @Override
+      public <T> List<T> impl(List<List<T>> collections) {
+        if (collections.isEmpty()) {
+          return List.of();
+        }
+
+        final var first = collections.getFirst();
+        final var rest = collections.stream().skip(1).toList();
+
+        return first.stream().filter(l -> rest.stream().allMatch(r -> r.contains(l))).toList();
+      }
+    },
+    DIFFERENCE("difference", false, 1) {
+      @Override
+      public <T> List<T> impl(List<List<T>> collections) {
+        if (collections.isEmpty()) {
+          return List.of();
+        }
+
+        final var first = collections.getFirst();
+        final var rest = collections.stream().skip(1).toList();
+
+        return first.stream().filter(l -> rest.stream().noneMatch(r -> r.contains(l))).toList();
+      }
+    };
+
+    final String name;
+    final boolean aggregationMode;
+    final int minFunctionArgs;
+
+    FunctionDefinition(String name, boolean aggregationMode, int minFunctionArgs) {
+      this.name = name;
+      this.aggregationMode = aggregationMode;
+      this.minFunctionArgs = minFunctionArgs;
+    }
+
+    public abstract <T> List<T> impl(List<List<T>> collections);
+  }
+}

--- a/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLFunctionsTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLFunctionsTest.java
@@ -263,20 +263,6 @@ public class SQLFunctionsTest extends BaseDBTest {
   }
 
   @Test
-  public void queryUnionAllAsAggregationNotRemoveDuplicates() {
-    List<EntityImpl> result =
-        database.query("select from City").stream().map(r -> (EntityImpl) r.toEntity()).toList();
-    int count = result.size();
-
-    result =
-        database.query("select unionAll(name) as name from City").stream()
-            .map(r -> (EntityImpl) r.toEntity())
-            .toList();
-    Collection<Object> citiesFound = result.get(0).field("name");
-    Assert.assertEquals(citiesFound.size(), count);
-  }
-
-  @Test
   public void querySetNotDuplicates() {
     List<EntityImpl> result =
         database.query("select set(name) as name from City").stream()
@@ -369,20 +355,6 @@ public class SQLFunctionsTest extends BaseDBTest {
     for (EntityImpl d : result) {
       Map<Object, Object> citiesFound = d.field("names");
       Assert.assertTrue(citiesFound.size() > 1);
-    }
-  }
-
-  @Test
-  public void queryUnionAllAsInline() {
-    List<EntityImpl> result =
-        database.query("select unionAll(out, in) as edges from V").stream()
-            .map(r -> (EntityImpl) r.toEntity())
-            .toList();
-
-    Assert.assertTrue(result.size() > 1);
-    for (EntityImpl d : result) {
-      Assert.assertEquals(d.fieldNames().length, 1);
-      Assert.assertTrue(d.containsField("edges"));
     }
   }
 


### PR DESCRIPTION
1. Improved distinction between aggregation and projection/per-record modes in implementations of SQLFunction by using `CommanContext#setVariable("aggregation", true|false)`. Now `unionAll`, `intersect` and `difference` with 1 parameter work in per-record mode.
2. Fix for queries that contain `LET $v = intersect($v1, $v2)` and `LET $v = difference($v1, $v2)`, where `$v1` and `$v2` are themselves subqueries.
3. iMinParams = 1 for `difference`. 
4. `difference` implementation improvements.
5. Better unit tests for `unionAll`, `intersect` and `difference`.