### PR TITLE
TransactionRollbackRate metric fix

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/tx/TransactionOptimistic.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/tx/TransactionOptimistic.java
@@ -782,7 +782,7 @@ public class TransactionOptimistic extends FrontendTransactionAbstract implement
     try {
       status = TXSTATUS.COMMITTING;
 
-      if (isWriteTransaction()) {
+      if (sentToServer || isWriteTransaction()) {
         database.internalCommit(this);
         database.transactionMeters()
             .writeTransactions()
@@ -806,7 +806,7 @@ public class TransactionOptimistic extends FrontendTransactionAbstract implement
   }
 
   private boolean isWriteTransaction() {
-    return sentToServer || !recordOperations.isEmpty() || !indexEntries.isEmpty();
+    return !recordOperations.isEmpty() || !indexEntries.isEmpty();
   }
 
   public void resetChangesTracking() {

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/tx/TransactionOptimistic.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/tx/TransactionOptimistic.java
@@ -384,9 +384,12 @@ public class TransactionOptimistic extends FrontendTransactionAbstract implement
 
   public void internalRollback() {
     status = TXSTATUS.ROLLBACKING;
-    database.transactionMeters()
-        .rollbackTransactions()
-        .record();
+
+    if (isWriteTransaction()) {
+      database.transactionMeters()
+          .rollbackTransactions()
+          .record();
+    }
 
     invalidateChangesInCache();
 
@@ -779,7 +782,7 @@ public class TransactionOptimistic extends FrontendTransactionAbstract implement
     try {
       status = TXSTATUS.COMMITTING;
 
-      if (sentToServer || !recordOperations.isEmpty() || !indexEntries.isEmpty()) {
+      if (isWriteTransaction()) {
         database.internalCommit(this);
         database.transactionMeters()
             .writeTransactions()
@@ -800,6 +803,10 @@ public class TransactionOptimistic extends FrontendTransactionAbstract implement
 
     close();
     status = TXSTATUS.COMPLETED;
+  }
+
+  private boolean isWriteTransaction() {
+    return sentToServer || !recordOperations.isEmpty() || !indexEntries.isEmpty();
   }
 
   public void resetChangesTracking() {


### PR DESCRIPTION
`TransactionRollbackRate` metric now ignores read-only transactions