### PR TITLE
Fixing import of vertex and edge classes in DatabaseImport tool

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
@@ -970,28 +970,28 @@ public abstract class DatabaseSessionAbstract<IM extends IndexManagerAbstract> e
 
       final RawBuffer recordBuffer;
       if (!rid.isValidPosition()) {
-        recordBuffer = null;
-      } else {
-        try {
-          var readRecordResult =
-              getStorage().readRecord(this, rid, fetchPreviousRid, fetchNextRid);
-          recordBuffer = readRecordResult.buffer();
+        throw new DatabaseException(getDatabaseName(), "Invalid record id " + rid);
+      }
 
-          previousRid = readRecordResult.previousRecordId();
-          nextRid = readRecordResult.nextRecordId();
-        } catch (RecordNotFoundException e) {
-          if (throwExceptionIfRecordNotFound) {
-            throw e;
-          } else {
-            if (fetchNextRid) {
-              nextRid = fetchNextRid(rid);
-            }
-            if (fetchPreviousRid) {
-              previousRid = fetchPreviousRid(rid);
-            }
+      try {
+        var readRecordResult =
+            getStorage().readRecord(this, rid, fetchPreviousRid, fetchNextRid);
+        recordBuffer = readRecordResult.buffer();
 
-            return new LoadRecordResult(null, previousRid, nextRid);
+        previousRid = readRecordResult.previousRecordId();
+        nextRid = readRecordResult.nextRecordId();
+      } catch (RecordNotFoundException e) {
+        if (throwExceptionIfRecordNotFound) {
+          throw e;
+        } else {
+          if (fetchNextRid) {
+            nextRid = fetchNextRid(rid);
           }
+          if (fetchPreviousRid) {
+            previousRid = fetchPreviousRid(rid);
+          }
+
+          return new LoadRecordResult(null, previousRid, nextRid);
         }
       }
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseExport.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseExport.java
@@ -67,6 +67,10 @@ public class DatabaseExport extends DatabaseImpExpAbstract {
 
   private final String tempFileName;
 
+  // these classes will be exported first. import tool relies on this order.
+  private static final Set<String> PRIORITY_EXPORT_CLASSES =
+      Set.of(SchemaClass.VERTEX_CLASS_NAME, SchemaClass.EDGE_CLASS_NAME);
+
   public DatabaseExport(
       final DatabaseSessionInternal iDatabase,
       final String iFileName,
@@ -472,7 +476,14 @@ public class DatabaseExport extends DatabaseImpExpAbstract {
       jsonGenerator.writeArrayFieldStart("classes");
 
       final List<SchemaClass> classes = new ArrayList<>(schema.getClasses());
-      classes.sort(Comparator.comparing(SchemaClass::getName));
+      classes.sort(Comparator.comparing(SchemaClass::getName, (n1, n2) -> {
+        final var n1priority = PRIORITY_EXPORT_CLASSES.contains(n1);
+        final var n2priority = PRIORITY_EXPORT_CLASSES.contains(n2);
+        if (n1priority == n2priority) {
+          return n1.compareTo(n2);
+        } else
+          return n1priority ? -1 : 1;
+      }));
 
       for (var cls : classes) {
         // CHECK TO FILTER CLASS

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseImport.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseImport.java
@@ -99,7 +99,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
   public static final int IMPORT_RECORD_DUMP_LAP_EVERY_MS = 5000;
 
   private final Map<SchemaProperty, String> linkedClasses = new HashMap<>();
-  private final Map<SchemaClass, List<String>> superClasses = new HashMap<>();
+  private final Map<String, List<String>> superClasses = new HashMap<>();
   private JSONReader jsonReader;
   private int exporterVersion = -1;
   private RID schemaRecordId;
@@ -610,24 +610,12 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
           className = newClassName;
         }
 
-        var cls = session.getMetadata().getSchema().getClass(className);
-
-        if (cls == null) {
-          if (collectionsImported) {
-            cls =
-                session
-                    .getMetadata()
-                    .getSchema()
-                    .createClass(className, classCollectionIds);
-          } else {
-            if (className.equalsIgnoreCase("ORestricted")) {
-              cls = session.getMetadata().getSchema()
-                  .createAbstractClass(className);
-            } else {
-              cls = session.getMetadata().getSchema().createClass(className);
-            }
-          }
-        }
+        Boolean strictMode = null;
+        Boolean isAbstract = null;
+        var isVertex = false;
+        var isEdge = false;
+        Map<String, String> customFields = null;
+        List<Map<String, Object>> propertiesRaw = null;
 
         String value;
         while (jsonReader.lastChar() == ',') {
@@ -635,16 +623,21 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
           value = jsonReader.getValue();
 
           switch (value) {
-            case "\"strictMode\"" ->
-                cls.setStrictMode(jsonReader.readBoolean(JSONReader.NEXT_IN_OBJECT));
-            case "\"abstract\"" ->
-                cls.setAbstract(jsonReader.readBoolean(JSONReader.NEXT_IN_OBJECT));
+            case "\"strictMode\"" -> strictMode = jsonReader.readBoolean(JSONReader.NEXT_IN_OBJECT);
+            case "\"abstract\"" -> isAbstract = jsonReader.readBoolean(JSONReader.NEXT_IN_OBJECT);
             case "\"super-class\"" -> {
               // @compatibility <2.1 SINGLE CLASS ONLY
               final var classSuper = jsonReader.readString(JSONReader.NEXT_IN_OBJECT);
-              final List<String> superClassNames = new ArrayList<>();
-              superClassNames.add(classSuper);
-              superClasses.put(cls, superClassNames);
+
+              if (SchemaClass.VERTEX_CLASS_NAME.equals(classSuper)) {
+                isVertex = true;
+              } else if (SchemaClass.EDGE_CLASS_NAME.equals(classSuper)) {
+                isEdge = true;
+              } else {
+                final List<String> superClassNames = new ArrayList<>();
+                superClassNames.add(classSuper);
+                superClasses.put(className, superClassNames);
+              }
             }
             case "\"super-classes\"" -> {
               // MULTIPLE CLASSES
@@ -654,33 +647,87 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
               while (jsonReader.lastChar() != ']') {
                 jsonReader.readNext(JSONReader.NEXT_IN_ARRAY);
 
-                final var clsName = jsonReader.getValue();
+                final var clsName = IOUtils.getStringContent(jsonReader.getValue());
 
-                superClassNames.add(IOUtils.getStringContent(clsName));
+                if (SchemaClass.VERTEX_CLASS_NAME.equals(clsName)) {
+                  isVertex = true;
+                } else if (SchemaClass.EDGE_CLASS_NAME.equals(clsName)) {
+                  isEdge = true;
+                } else {
+                  superClassNames.add(clsName);
+                }
+              }
+
+              if (!superClassNames.isEmpty()) {
+                superClasses.put(className, superClassNames);
               }
               jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
-
-              superClasses.put(cls, superClassNames);
             }
             case "\"properties\"" -> {
+              propertiesRaw = new ArrayList<>();
               // GET PROPERTIES
               jsonReader.readNext(JSONReader.BEGIN_COLLECTION);
 
               while (jsonReader.lastChar() != ']') {
-                importProperty((SchemaClassInternal) cls);
-
-                if (jsonReader.lastChar() == '}') {
-                  jsonReader.readNext(JSONReader.NEXT_IN_ARRAY);
-                }
+                final var pRaw = jsonReader.readNext(JSONReader.NEXT_IN_ARRAY).getValue();
+                final var pMap = JSONSerializerJackson.mapFromJson(pRaw);
+                propertiesRaw.add(pMap);
               }
               jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
             }
             case "\"customFields\"" -> {
-              var customFields = importCustomFields();
-              for (var entry : customFields.entrySet()) {
-                cls.setCustom(entry.getKey(), entry.getValue());
-              }
+              customFields = importCustomFields();
             }
+          }
+        }
+
+        if (isVertex && isEdge) {
+          throw new DatabaseImportException(
+              "Class '" + className + "' cannot be both vertex and edge.");
+        }
+
+        final var schema = session.getMetadata().getSchema();
+        var cls = schema.getClass(className);
+
+        if (cls != null) {
+          if (isVertex && !cls.isVertexType()) {
+            throw new DatabaseImportException("Class '" + className
+                + "' exists but is not a vertex class. It can't be made a vertex class.");
+          } else if (isEdge && !cls.isEdgeType()) {
+            throw new DatabaseImportException("Class '" + className
+                + "' exists but is not an edge class. It can't be made an edge class."
+            );
+          }
+        } else {
+          if (isVertex) {
+            cls = schema.createVertexClass(className);
+          } else if (isEdge) {
+            cls = schema.createEdgeClass(className);
+          } else if (collectionsImported) {
+            cls = schema.createClass(className, classCollectionIds);
+          } else if (className.equalsIgnoreCase("ORestricted")) {
+            cls = schema.createAbstractClass(className);
+          } else {
+            cls = schema.createClass(className);
+          }
+        }
+
+        if (strictMode != null) {
+          cls.setStrictMode(strictMode);
+        }
+        if (isAbstract != null) {
+          cls.setAbstract(isAbstract);
+        }
+
+        if (propertiesRaw != null) {
+          for (var propRaw : propertiesRaw) {
+            importProperty((SchemaClassInternal) cls, propRaw);
+          }
+        }
+
+        if (customFields != null) {
+          for (var cf : customFields.entrySet()) {
+            cls.setCustom(cf.getKey(), cf.getValue());
           }
         }
 
@@ -689,7 +736,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
         jsonReader.readNext(JSONReader.NEXT_IN_ARRAY);
       } while (jsonReader.lastChar() == ',');
 
-      this.rebuildCompleteClassInheritence();
+      this.rebuildCompleteClassInheritance();
       this.setLinkedClasses();
 
       if (exporterVersion < 11) {
@@ -706,118 +753,39 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
     }
   }
 
-  private void rebuildCompleteClassInheritence() {
+  private void rebuildCompleteClassInheritance() {
     for (final var entry : superClasses.entrySet()) {
+      final var cls = session.getMetadata().getSchema().getClass(entry.getKey());
+
       for (final var superClassName : entry.getValue()) {
         final var superClass = session.getMetadata().getSchema().getClass(superClassName);
 
-        if (!entry.getKey().getSuperClasses().contains(superClass)) {
-          final var schemaClass =
-              ((SchemaClassEmbedded) ((SchemaClassInternal) entry.getKey()).getImplementation());
-          schemaClass.addSuperClassInternal(
-              session,
-              ((SchemaClassInternal) superClass).getImplementation(),
-              true
-          );
+        if (!cls.getSuperClasses().contains(superClass)) {
+          cls.addSuperClass(superClass);
         }
       }
     }
   }
 
-  private void importProperty(final SchemaClassInternal iClass) throws IOException, ParseException {
-    jsonReader.readNext(JSONReader.NEXT_OBJ_IN_ARRAY);
+  private void importProperty(final SchemaClassInternal iClass, Map<String, ?> propRaw) {
 
-    if (jsonReader.lastChar() == ']') {
-      return;
-    }
+    final var propName = (String) propRaw.get("name");
 
-    final var propName =
-        jsonReader
-            .readNext(JSONReader.FIELD_ASSIGNMENT)
-            .checkContent("\"name\"")
-            .readString(JSONReader.COMMA_SEPARATOR);
+    final var type = PropertyTypeInternal.valueOf(((String) propRaw.get("type")));
 
-    var next = jsonReader.readNext(JSONReader.FIELD_ASSIGNMENT).getValue();
-
-    if (next.equals("\"id\"")) {
-      // @COMPATIBILITY 1.0rc4 IGNORE THE ID
-      jsonReader.readString(JSONReader.COMMA_SEPARATOR);
-      jsonReader.readNext(JSONReader.FIELD_ASSIGNMENT);
-    }
-    next = jsonReader.checkContent("\"type\"").readString(JSONReader.NEXT_IN_OBJECT);
-
-    final var type = PropertyTypeInternal.valueOf(next);
-
-    String attrib;
-    String value = null;
-
-    String min = null;
-    String max = null;
-    String linkedClass = null;
-    PropertyTypeInternal linkedType = null;
-    var mandatory = false;
-    var readonly = false;
-    var notNull = false;
-    String collate = null;
-    String regexp = null;
-    String defaultValue = null;
-
-    Map<String, String> customFields = null;
-
-    while (jsonReader.lastChar() == ',') {
-      jsonReader.readNext(JSONReader.FIELD_ASSIGNMENT);
-
-      attrib = jsonReader.getValue();
-      if (!attrib.equals("\"customFields\"")) {
-        value =
-            jsonReader.readString(
-                JSONReader.NEXT_IN_OBJECT, false, JSONReader.DEFAULT_JUMP, null, false);
-      }
-
-      if (attrib.equals("\"min\"")) {
-        min = value;
-      } else {
-        if (attrib.equals("\"max\"")) {
-          max = value;
-        } else {
-          if (attrib.equals("\"linked-class\"")) {
-            linkedClass = value;
-          } else {
-            if (attrib.equals("\"mandatory\"")) {
-              mandatory = Boolean.parseBoolean(value);
-            } else {
-              if (attrib.equals("\"readonly\"")) {
-                readonly = Boolean.parseBoolean(value);
-              } else {
-                if (attrib.equals("\"not-null\"")) {
-                  notNull = Boolean.parseBoolean(value);
-                } else {
-                  if (attrib.equals("\"linked-type\"")) {
-                    linkedType = PropertyTypeInternal.valueOf(value);
-                  } else {
-                    if (attrib.equals("\"collate\"")) {
-                      collate = value;
-                    } else {
-                      if (attrib.equals("\"default-value\"")) {
-                        defaultValue = value;
-                      } else {
-                        if (attrib.equals("\"customFields\"")) {
-                          customFields = importCustomFields();
-                        } else {
-                          if (attrib.equals("\"regexp\"")) {
-                            regexp = value;
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    }
+    final var min = (String) propRaw.get("min");
+    final var max = (String) propRaw.get("max");
+    final var linkedClass = (String) propRaw.get("linked-class");
+    final var linkedType =
+        propRaw.containsKey("linked-type") ? PropertyTypeInternal.valueOf(
+            (String) propRaw.get("linked-type")) : null;
+    final var mandatory = propRaw.containsKey("mandatory") && (boolean) propRaw.get("mandatory");
+    final var readonly = propRaw.containsKey("readonly") && (boolean) propRaw.get("readonly");
+    final var notNull = propRaw.containsKey("not-null") && (boolean) propRaw.get("not-null");
+    final var collate = (String) propRaw.get("collate");
+    final var regexp = (String) propRaw.get("regexp");
+    final var defaultValue = (String) propRaw.get("default-value");
+    final var customFields = (Map<String, String>) propRaw.get("customFields");
 
     var prop = iClass.getProperty(propName);
     if (prop == null) {
@@ -849,7 +817,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       prop.setRegexp(regexp);
     }
     if (defaultValue != null) {
-      prop.setDefaultValue(value);
+      prop.setDefaultValue(defaultValue);
     }
     if (customFields != null) {
       for (var entry : customFields.entrySet()) {
@@ -1062,8 +1030,11 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
     RID rid = null;
     RID originalRid = null;
     try {
-      var recordJson =
-          jsonReader.readRecordString(this.maxRidbagStringSizeBeforeLazyImport).getKey().trim();
+
+      // commenting this out for now, because it can clear large LinkBags:
+      // var recordJson = jsonReader.readRecordString(this.maxRidbagStringSizeBeforeLazyImport).getKey().trim();
+      var recordJson = jsonReader.readNext(JSONReader.NEXT_IN_ARRAY).getValue();
+
       if (recordJson.isEmpty()) {
         return null;
       }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaClassEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaClassEmbedded.java
@@ -121,54 +121,51 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
 
   public void addSuperClass(DatabaseSessionInternal session,
       final SchemaClassImpl superClass) {
-    session.checkSecurity(Rule.ResourceGeneric.SCHEMA, Role.PERMISSION_UPDATE);
-    checkParametersConflict(session, superClass);
-    acquireSchemaWriteLock(session);
-    try {
-      addSuperClassInternal(session, superClass);
-    } finally {
-      releaseSchemaWriteLock(session);
-    }
+    addSuperClassInternal(session, superClass, false);
   }
 
-  protected void addSuperClassInternal(DatabaseSessionInternal session,
-      final SchemaClassImpl superClass) {
+  public void addSuperClassInternal(
+      DatabaseSessionInternal session,
+      final SchemaClassImpl superClass,
+      boolean allowGraphClasses
+  ) {
+
+    session.checkSecurity(Rule.ResourceGeneric.SCHEMA, Role.PERMISSION_UPDATE);
+    checkParametersConflict(session, superClass);
     acquireSchemaWriteLock(session);
     try {
       final SchemaClassImpl cls;
       cls = superClass;
 
-      if (cls != null) {
-
-        if (superClass.getName(session).equals(SchemaClassProxy.VERTEX_CLASS_NAME) ||
-            superClass.getName(session).equals(SchemaClassProxy.EDGE_CLASS_NAME)) {
-          throw new SchemaException(session.getDatabaseName(),
-              "Cannot add the class '"
-                  + superClass.getName(session)
-                  + "' as superclass of the class '"
-                  + this.getName(session)
-                  + "'. Addition of graph classes is not allowed");
-        }
-
-        // CHECK THE USER HAS UPDATE PRIVILEGE AGAINST EXTENDING CLASS
-        final var user = session.getCurrentUser();
-        if (user != null) {
-          user.allow(session, Rule.ResourceGeneric.CLASS, cls.getName(session),
-              Role.PERMISSION_UPDATE);
-        }
-
-        if (superClasses.contains(superClass)) {
-          throw new SchemaException(session.getDatabaseName(),
-              "Class: '"
-                  + this.getName(session)
-                  + "' already has the class '"
-                  + superClass.getName(session)
-                  + "' as superclass");
-        }
-
-        cls.addBaseClass(session, this);
-        superClasses.add(cls);
+      if (!allowGraphClasses &&
+          (superClass.getName(session).equals(SchemaClassProxy.VERTEX_CLASS_NAME) ||
+          superClass.getName(session).equals(SchemaClassProxy.EDGE_CLASS_NAME))) {
+        throw new SchemaException(session.getDatabaseName(),
+            "Cannot add the class '"
+                + superClass.getName(session)
+                + "' as superclass of the class '"
+                + this.getName(session)
+                + "'. Addition of graph classes is not allowed");
       }
+
+      // CHECK THE USER HAS UPDATE PRIVILEGE AGAINST EXTENDING CLASS
+      final var user = session.getCurrentUser();
+      if (user != null) {
+        user.allow(session, Rule.ResourceGeneric.CLASS, cls.getName(session),
+            Role.PERMISSION_UPDATE);
+      }
+
+      if (superClasses.contains(superClass)) {
+        throw new SchemaException(session.getDatabaseName(),
+            "Class: '"
+                + this.getName(session)
+                + "' already has the class '"
+                + superClass.getName(session)
+                + "' as superclass");
+      }
+
+      cls.addBaseClass(session, this);
+      superClasses.add(cls);
     } finally {
       releaseSchemaWriteLock(session);
     }
@@ -203,9 +200,7 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
       cls = superClass;
 
       if (superClasses.contains(cls)) {
-        if (cls != null) {
-          cls.removeBaseClassInternal(session, this);
-        }
+        cls.removeBaseClassInternal(session, this);
 
         superClasses.remove(superClass);
       }
@@ -250,7 +245,7 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
       }
     }
 
-    List<SchemaClassImpl> newSuperClasses = new ArrayList<SchemaClassImpl>();
+    List<SchemaClassImpl> newSuperClasses = new ArrayList<>();
     SchemaClassImpl cls;
     for (var superClass : classes) {
       cls = superClass;
@@ -262,9 +257,9 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
       newSuperClasses.add(cls);
     }
 
-    List<SchemaClassImpl> toAddList = new ArrayList<SchemaClassImpl>(newSuperClasses);
+    List<SchemaClassImpl> toAddList = new ArrayList<>(newSuperClasses);
     toAddList.removeAll(superClasses);
-    List<SchemaClassImpl> toRemoveList = new ArrayList<SchemaClassImpl>(superClasses);
+    List<SchemaClassImpl> toRemoveList = new ArrayList<>(superClasses);
     toRemoveList.removeAll(newSuperClasses);
 
     for (var toRemove : toRemoveList) {
@@ -520,7 +515,7 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
       checkEmbedded(session);
 
       if (customFields == null) {
-        customFields = new HashMap<String, String>();
+        customFields = new HashMap<>();
       }
       if (value == null || "null".equalsIgnoreCase(value)) {
         customFields.remove(name);
@@ -645,7 +640,7 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
 
   protected void addCollectionIdToIndexes(DatabaseSessionInternal session, int iId) {
     var collectionName = session.getCollectionNameById(iId);
-    final List<String> indexesToAdd = new ArrayList<String>();
+    final List<String> indexesToAdd = new ArrayList<>();
 
     for (var index : getIndexesInternal(session)) {
       indexesToAdd.add(index.getName());

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaClassEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaClassEmbedded.java
@@ -121,25 +121,20 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
 
   public void addSuperClass(DatabaseSessionInternal session,
       final SchemaClassImpl superClass) {
-    addSuperClassInternal(session, superClass, false);
-  }
-
-  public void addSuperClassInternal(
-      DatabaseSessionInternal session,
-      final SchemaClassImpl superClass,
-      boolean allowGraphClasses
-  ) {
 
     session.checkSecurity(Rule.ResourceGeneric.SCHEMA, Role.PERMISSION_UPDATE);
     checkParametersConflict(session, superClass);
+    addSuperClassInternal(session, superClass);
+  }
+
+  public void addSuperClassInternal(DatabaseSessionInternal session,
+      final SchemaClassImpl superClass) {
+
     acquireSchemaWriteLock(session);
     try {
-      final SchemaClassImpl cls;
-      cls = superClass;
 
-      if (!allowGraphClasses &&
-          (superClass.getName(session).equals(SchemaClassProxy.VERTEX_CLASS_NAME) ||
-          superClass.getName(session).equals(SchemaClassProxy.EDGE_CLASS_NAME))) {
+      if (superClass.getName(session).equals(SchemaClassProxy.VERTEX_CLASS_NAME) ||
+          superClass.getName(session).equals(SchemaClassProxy.EDGE_CLASS_NAME)) {
         throw new SchemaException(session.getDatabaseName(),
             "Cannot add the class '"
                 + superClass.getName(session)
@@ -151,7 +146,7 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
       // CHECK THE USER HAS UPDATE PRIVILEGE AGAINST EXTENDING CLASS
       final var user = session.getCurrentUser();
       if (user != null) {
-        user.allow(session, Rule.ResourceGeneric.CLASS, cls.getName(session),
+        user.allow(session, Rule.ResourceGeneric.CLASS, superClass.getName(session),
             Role.PERMISSION_UPDATE);
       }
 
@@ -164,8 +159,8 @@ public class SchemaClassEmbedded extends SchemaClassImpl {
                 + "' as superclass");
       }
 
-      cls.addBaseClass(session, this);
-      superClasses.add(cls);
+      superClass.addBaseClass(session, this);
+      superClasses.add(superClass);
     } finally {
       releaseSchemaWriteLock(session);
     }

--- a/core/src/test/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseImportTest.java
+++ b/core/src/test/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseImportTest.java
@@ -25,6 +25,8 @@ public class DatabaseImportTest {
     final var output = new ByteArrayOutputStream();
     try (final var db = youTrackDB.open(databaseName, "admin", "admin")) {
       db.getSchema().createClass("SimpleClass");
+      db.getSchema().createVertexClass("SimpleVertexClass");
+      db.getSchema().createEdgeClass("SimpleEdgeClass");
 
       final var export =
           new DatabaseExport((DatabaseSessionInternal) db, output, iText -> {
@@ -49,7 +51,12 @@ public class DatabaseImportTest {
               iText -> {
               });
       importer.importDatabase();
-      Assert.assertTrue(db.getMetadata().getSchema().existsClass("SimpleClass"));
+      final var schema = db.getMetadata().getSchema();
+      Assert.assertTrue(schema.existsClass("SimpleClass"));
+      Assert.assertTrue(schema.existsClass("SimpleVertexClass"));
+      Assert.assertTrue(schema.existsClass("SimpleEdgeClass"));
+      Assert.assertTrue(schema.getClass("SimpleVertexClass").isVertexType());
+      Assert.assertTrue(schema.getClass("SimpleEdgeClass").isEdgeType());
     }
     youTrackDB.drop(databaseName);
     youTrackDB.close();


### PR DESCRIPTION
The new validation for adding "V" and "E" super classes made it impossible to import a schema with vertexes and edges. This has been fixed by adding a new flag for skipping the validation to `SchemaClassEmbedded#addSuperClassInternal`.