### PR TITLE
Add edge + remove vertex fix

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseDocumentTx.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseDocumentTx.java
@@ -1450,7 +1450,7 @@ public class DatabaseDocumentTx implements DatabaseSessionInternal {
   }
 
   @Override
-  public void deleteInternal(@Nonnull DBRecord record) {
+  public void deleteInternal(@Nonnull RecordAbstract record) {
     checkOpenness();
     internal.deleteInternal(record);
   }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
@@ -505,13 +505,14 @@ public abstract class DatabaseSessionAbstract<IM extends IndexManagerAbstract> e
   }
 
   @Override
-  public void deleteInternal(@Nonnull DBRecord record) {
+  public void deleteInternal(@Nonnull RecordAbstract record) {
     checkOpenness();
     assert assertIfNotActive();
 
     if (record instanceof EntityImpl entity) {
       ensureEdgeConsistencyOnDeletion(entity);
     }
+    record.dirty++;
 
     try {
       checkTxActive();

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionInternal.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionInternal.java
@@ -269,7 +269,7 @@ public interface DatabaseSessionInternal extends DatabaseSession {
 
   boolean isCollectionEdge(int collection);
 
-  void deleteInternal(@Nonnull DBRecord record);
+  void deleteInternal(@Nonnull RecordAbstract record);
 
   void internalClose(boolean recycle);
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/RecordAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/RecordAbstract.java
@@ -60,7 +60,7 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
   protected int size;
 
   public RecordSerializer recordSerializer;
-  protected long dirty = 1;
+  public long dirty = 1;
   protected boolean contentChanged = true;
   protected STATUS status = STATUS.NOT_LOADED;
 
@@ -327,7 +327,6 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
     //preprocess any creation, deletion operations
     tx.preProcessRecordsAndExecuteCallCallbacks();
 
-    dirty++;
     session.deleteInternal(this);
     internalReset();
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/impl/VertexEntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/impl/VertexEntityImpl.java
@@ -169,7 +169,7 @@ public class VertexEntityImpl extends EntityImpl implements Vertex {
 
     var schemaClass = session.getClass(type);
     if (schemaClass == null) {
-      throw new IllegalArgumentException("Schema class for label" + type + " not found");
+      throw new IllegalArgumentException("Schema class for label " + type + " not found");
     }
     if (schemaClass.isAbstract()) {
       return session.newLightweightEdge(this, to, type);

--- a/core/src/test/java/com/jetbrains/youtrack/db/internal/core/record/impl/VertexAndEdgeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrack/db/internal/core/record/impl/VertexAndEdgeTest.java
@@ -1,5 +1,10 @@
 package com.jetbrains.youtrack.db.internal.core.record.impl;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import com.jetbrains.youtrack.db.api.exception.RecordNotFoundException;
+import com.jetbrains.youtrack.db.api.record.Direction;
 import com.jetbrains.youtrack.db.internal.DbTestBase;
 import com.jetbrains.youtrack.db.internal.common.util.Pair;
 import org.junit.Test;
@@ -22,7 +27,18 @@ public class VertexAndEdgeTest extends DbTestBase {
 
       v1.addEdge(v2, "E");
       v2.delete();
+    });
 
+    try {
+      session.executeInTx(tx -> tx.load(p.getValue()));
+      fail("Should throw RecordNotFoundException");
+    } catch (RecordNotFoundException ex) {
+      // ok
+    }
+
+    session.executeInTx(tx -> {
+      final var v1 = tx.loadVertex(p.getKey());
+      assertThat(v1.getEdges(Direction.BOTH)).isEmpty();
     });
   }
 }

--- a/core/src/test/java/com/jetbrains/youtrack/db/internal/core/record/impl/VertexAndEdgeTest.java
+++ b/core/src/test/java/com/jetbrains/youtrack/db/internal/core/record/impl/VertexAndEdgeTest.java
@@ -1,0 +1,28 @@
+package com.jetbrains.youtrack.db.internal.core.record.impl;
+
+import com.jetbrains.youtrack.db.internal.DbTestBase;
+import com.jetbrains.youtrack.db.internal.common.util.Pair;
+import org.junit.Test;
+
+public class VertexAndEdgeTest extends DbTestBase {
+
+  @Test
+  public void testAddEdgeAndDeleteVertex() {
+
+    final var p = session.computeInTx(tx -> {
+      var v1 = tx.newVertex();
+      var v2 = tx.newVertex();
+
+      return new Pair<>(v1, v2);
+    });
+
+    session.executeInTx(tx -> {
+      var v1 = tx.loadVertex(p.getKey());
+      var v2 = tx.loadVertex(p.getValue());
+
+      v1.addEdge(v2, "E");
+      v2.delete();
+
+    });
+  }
+}


### PR DESCRIPTION
Fixed dirty counter assertion in simple scenario with edge addition and vertex deletion within the same transaction. Plus unit test covering this scenario.