### PR TITLE
Fixing order for intersect and difference functions

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
@@ -24,7 +24,7 @@ import com.jetbrains.youtrack.db.api.exception.CommandExecutionException;
 import com.jetbrains.youtrack.db.api.query.Result;
 import com.jetbrains.youtrack.db.internal.common.collection.MultiValue;
 import com.jetbrains.youtrack.db.internal.core.command.CommandContext;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
@@ -58,7 +58,7 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
     }
 
     // IN-LINE MODE (STATELESS)
-    final Set<Object> result = new HashSet<Object>();
+    final Set<Object> result = new LinkedHashSet<>();
 
     final var firstIt = MultiValue.getMultiValueIterator(iParams[0]);
     while (firstIt.hasNext()) {

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionIntersect.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionIntersect.java
@@ -105,6 +105,9 @@ public class SQLFunctionIntersect extends SQLFunctionMultiValueAbstract<Object> 
       iterator = MultiValue.getMultiValueIterator(value);
     }
 
+    // using linked hash set because we want
+    // 1) to remove duplicates when there is a single argument to the function
+    // 2) to preserve order of the input collection
     final Set<Object> result = new LinkedHashSet<>();
     while (iterator.hasNext()) {
       result.add(iterator.next());

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionIntersect.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionIntersect.java
@@ -27,11 +27,9 @@ import com.jetbrains.youtrack.db.internal.common.util.SupportsContains;
 import com.jetbrains.youtrack.db.internal.core.command.CommandContext;
 import com.jetbrains.youtrack.db.internal.core.db.record.ridbag.LinkBag;
 import com.jetbrains.youtrack.db.internal.core.sql.filter.SQLFilterItemVariable;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -55,14 +53,17 @@ public class SQLFunctionIntersect extends SQLFunctionMultiValueAbstract<Object> 
       Object iCurrentResult,
       final Object[] iParams,
       CommandContext iContext) {
-    var value = iParams[0];
 
-    if (value instanceof SQLFilterItemVariable) {
-      value = ((SQLFilterItemVariable) value).getValue(iCurrentRecord, iCurrentResult, iContext);
+    for (var p : iParams) {
+      if (p == null || (p instanceof Collection<?> col && col.isEmpty())) {
+        return Set.of();
+      }
     }
 
-    if (value == null) {
-      return Collections.emptySet();
+    var value = iParams[0];
+
+    if (value instanceof SQLFilterItemVariable fi) {
+      value = fi.getValue(iCurrentRecord, iCurrentResult, iContext);
     }
 
     if (Boolean.TRUE.equals(iContext.getVariable("aggregation"))) {
@@ -91,24 +92,20 @@ public class SQLFunctionIntersect extends SQLFunctionMultiValueAbstract<Object> 
     }
 
     // IN-LINE MODE (STATELESS)
-    Iterator iterator = MultiValue.getMultiValueIterator(value);
+    var iterator = MultiValue.getMultiValueIterator(value);
 
     for (var i = 1; i < iParams.length; ++i) {
       value = iParams[i];
 
-      if (value instanceof SQLFilterItemVariable) {
-        value = ((SQLFilterItemVariable) value).getValue(iCurrentRecord, iCurrentResult, iContext);
+      if (value instanceof SQLFilterItemVariable fi) {
+        value = fi.getValue(iCurrentRecord, iCurrentResult, iContext);
       }
 
-      if (value != null) {
-        value = intersectWith(iterator, value);
-        iterator = MultiValue.getMultiValueIterator(value);
-      } else {
-        return Collections.emptyIterator();
-      }
+      value = intersectWith(iterator, value);
+      iterator = MultiValue.getMultiValueIterator(value);
     }
 
-    List result = new ArrayList();
+    final Set<Object> result = new LinkedHashSet<>();
     while (iterator.hasNext()) {
       result.add(iterator.next());
     }
@@ -121,7 +118,7 @@ public class SQLFunctionIntersect extends SQLFunctionMultiValueAbstract<Object> 
   }
 
   static Collection intersectWith(final Iterator current, Object value) {
-    final var tempSet = new HashSet();
+    final var tempSet = new LinkedHashSet<>();
 
     if (!(value instanceof Set)
         && (!(value instanceof SupportsContains)

--- a/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLCombinationFunctionTests.java
+++ b/tests/src/test/java/com/jetbrains/youtrack/db/auto/SQLCombinationFunctionTests.java
@@ -1,6 +1,6 @@
 package com.jetbrains.youtrack.db.auto;
 
-import static org.junit.Assert.assertEquals;
+import static org.testng.Assert.assertEquals;
 
 import com.google.common.collect.Sets;
 import com.jetbrains.youtrack.db.api.exception.CommandExecutionException;
@@ -19,6 +19,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -259,6 +260,36 @@ public class SQLCombinationFunctionTests extends BaseDBTest {
     runEdgeInlineTest(FunctionDefinition.DIFFERENCE);
   }
 
+  @Test
+  public void unionAllOrderTest() {
+    runOrderTest(FunctionDefinition.UNION_ALL);
+  }
+
+  @Test
+  public void intersectOrderTest() {
+    runOrderTest(FunctionDefinition.INTERSECT);
+  }
+
+  @Test
+  public void differenceOrderTest() {
+    runOrderTest(FunctionDefinition.DIFFERENCE);
+  }
+
+  @Test
+  public void unionAllOneArgumentTest() {
+    runOneArgumentTest(FunctionDefinition.UNION_ALL);
+  }
+
+  @Test
+  public void intersectOneArgumentTest() {
+    runOneArgumentTest(FunctionDefinition.INTERSECT);
+  }
+
+  @Test
+  public void differenceOneArgumentTest() {
+    runOneArgumentTest(FunctionDefinition.DIFFERENCE);
+  }
+
   private void runEdgeInlineTest(FunctionDefinition fDef) {
 
     session.begin();
@@ -286,7 +317,7 @@ public class SQLCombinationFunctionTests extends BaseDBTest {
         r -> r.<RecordId>getProperty("@rid"),
         r -> r.<Collection<Identifiable>>getProperty("edges")
     ));
-    assertEquals(insAndOuts.keySet(), result.keySet());
+    assertEquals(result.keySet(), insAndOuts.keySet());
 
     for (var e : insAndOuts.entrySet()) {
       final var rid = e.getKey();
@@ -306,6 +337,61 @@ public class SQLCombinationFunctionTests extends BaseDBTest {
       assertListsEqualsIgnoreOrder(edges, expectedEdges);
     }
     session.commit();
+  }
+
+  private void runOrderTest(FunctionDefinition fDef) {
+
+    session.executeInTx(tx -> {
+
+      final var rand = new Random();
+      final var randomNumbers1 = rand.ints(35, 0, 10).boxed().toList();
+      final var randomNumbers2 = rand.ints(10, 0, 10).boxed().toList();
+
+      final var query =
+          "SELECT FROM $var3 LET "
+              + "$var1 = :someNumbers1, "
+              + "$var2 = :someNumbers2, "
+              + "$var3 = " + fDef.name + "($var1, $var2)";
+
+      var result =
+          tx.query(query, Map.of("someNumbers1", randomNumbers1, "someNumbers2", randomNumbers2))
+              .stream()
+              .map(r -> r.getInt("value"))
+              .toList();
+
+      var expected = fDef.impl(List.of(randomNumbers1, randomNumbers2));
+
+      assertEquals(
+          result, expected,
+          "Order was not preserved for " + fDef.name + " function. "
+              + "list1: " + randomNumbers1 + ",\n"
+              + "list2: " + randomNumbers2 + ",\n"
+              + "result: " + result + ",\n"
+              + "expected: " + expected
+      );
+    });
+  }
+
+  private void runOneArgumentTest(FunctionDefinition fDef) {
+    session.executeInTx(tx -> {
+      final var rand = new Random();
+      final var randomNumbers = rand.ints(35, 0, 10).boxed().toList();
+
+      final var query =
+          "SELECT FROM $var2 LET "
+              + "$var1 = :someNumbers, "
+              + "$var2 = " + fDef.name + "($var1);";
+
+       var result =
+          tx.query(query, Map.of("someNumbers", randomNumbers))
+              .stream()
+              .map(r -> r.getInt("value"))
+              .toList();
+
+      var expected = fDef.impl(List.of(randomNumbers));
+
+      assertEquals(result, expected);
+    });
   }
 
   private void generateGraphRandomData() {
@@ -455,7 +541,7 @@ public class SQLCombinationFunctionTests extends BaseDBTest {
   private static void assertListsEqualsIgnoreOrder(List<?> list1, List<?> list2, String message) {
     final var l1Sorted = list1.stream().sorted().toList();
     final var l2Sorted = list2.stream().sorted().toList();
-    Assert.assertEquals(l1Sorted, l2Sorted, message);
+    assertEquals(l1Sorted, l2Sorted, message);
   }
 
   private static Set<Set<String>> combinations(int minLength, int maxLength, Set<String> values) {
@@ -486,7 +572,9 @@ public class SQLCombinationFunctionTests extends BaseDBTest {
         final var first = collections.getFirst();
         final var rest = collections.stream().skip(1).toList();
 
-        return first.stream().filter(l -> rest.stream().allMatch(r -> r.contains(l))).toList();
+        return first.stream()
+            .distinct()
+            .filter(l -> rest.stream().allMatch(r -> r.contains(l))).toList();
       }
     },
     DIFFERENCE("difference", false, 1) {
@@ -499,7 +587,9 @@ public class SQLCombinationFunctionTests extends BaseDBTest {
         final var first = collections.getFirst();
         final var rest = collections.stream().skip(1).toList();
 
-        return first.stream().filter(l -> rest.stream().noneMatch(r -> r.contains(l))).toList();
+        return first.stream()
+            .distinct()
+            .filter(l -> rest.stream().noneMatch(r -> r.contains(l))).toList();
       }
     };
 


### PR DESCRIPTION
1. Preserving order for `intersect` and `difference` functions
2. Remove duplicates for one-argument intersect: `intersect(value)` to make it consistent with multi-argument options.
3. Some small optimizations
4. New unit tests