### PR TITLE
Fixing order for expand(intersect(...)) and expand(difference(...))

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifference.java
@@ -24,7 +24,9 @@ import com.jetbrains.youtrack.db.api.exception.CommandExecutionException;
 import com.jetbrains.youtrack.db.api.query.Result;
 import com.jetbrains.youtrack.db.internal.common.collection.MultiValue;
 import com.jetbrains.youtrack.db.internal.core.command.CommandContext;
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -39,7 +41,7 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
     super(NAME, 1, -1);
   }
 
-  @SuppressWarnings("unchecked")
+  @Override
   public Object execute(
       Object iThis,
       Result iCurrentRecord,
@@ -54,7 +56,7 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
 
     // if the first parameter is null, then the overall result is empty
     if (iParams[0] == null) {
-      return Set.of();
+      return List.of();
     }
 
     // IN-LINE MODE (STATELESS)
@@ -66,7 +68,7 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
     }
 
     if (result.isEmpty()) { // no need to iterate further
-      return Set.of();
+      return List.of();
     }
 
     for (var i = 1; i < iParams.length; i++) {
@@ -81,9 +83,13 @@ public class SQLFunctionDifference extends SQLFunctionMultiValueAbstract<Set<Obj
       }
     }
 
-    return result;
+    // still need to return a list here, because returning a Set can
+    // break the order, as some of our code performs collection copying based on
+    // "instanceof Set" check.
+    return new ArrayList<>(result);
   }
 
+  @Override
   public String getSyntax(DatabaseSession session) {
     return "difference(<field> [, <field]*)";
   }

--- a/core/src/test/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifferenceTest.java
+++ b/core/src/test/java/com/jetbrains/youtrack/db/internal/core/sql/functions/coll/SQLFunctionDifferenceTest.java
@@ -43,10 +43,10 @@ public class SQLFunctionDifferenceTest {
     Set<Object> expectedResult = new HashSet<Object>(List.<Object>of(4));
 
     var actualResult =
-        (Set<Object>)
+        (List<Object>)
             function.execute(null, null, null, incomes.toArray(), new BasicCommandContext());
 
-    assertSetEquals(actualResult, expectedResult);
+    assertSetEquals(new HashSet<>(actualResult), expectedResult);
 
     incomes =
         Arrays.asList(Arrays.asList(1, 2, 3, 4, 5, 1), Arrays.asList(3, 5, 6, 7, 0, 1, 3, 3, 6));
@@ -54,9 +54,9 @@ public class SQLFunctionDifferenceTest {
     expectedResult = new HashSet<Object>(Arrays.<Object>asList(2, 4));
 
     actualResult =
-        (Set<Object>)
+        (List<Object>)
             function.execute(null, null, null, incomes.toArray(), new BasicCommandContext());
-    assertSetEquals(actualResult, expectedResult);
+    assertSetEquals(new HashSet<>(actualResult), expectedResult);
   }
 
   private void assertSetEquals(Set<Object> actualResult, Set<Object> expectedResult) {


### PR DESCRIPTION
Looks like it was a bad idea to return LinkedHashSet from SQLFunctionIntersect and SQLFunctionDifference, because when using these functions together with expand, our code performs copying of these collections based on instanceof checks. So all sets were copied to another sets, breaking the ordering of the original collections.

We have a Slack chat for contributors. If you wish to join, please
read [this article](https://youtrack.jetbrains.com/articles/YTDB-A-5/Slack-with-developers-for-contributors).
