### PR TITLE
Fix for linkbag index not being updated

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/impl/EntityImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/impl/EntityImpl.java
@@ -1322,6 +1322,12 @@ public class EntityImpl extends RecordAbstract implements Entity {
           if (PropertyTypeInternal.isSingleValueType(value) && Objects.equals(oldValue, value)) {
             return value;
           }
+          // skipping the update if the value is the same instance of a multi-value type,
+          // otherwise the code below will remove any tracking data from it, and we can lose
+          // an update.
+          if (oldValue == value) {
+            return value;
+          }
         }
       } catch (Exception e) {
         LogManager.instance()


### PR DESCRIPTION
When a tracked multi-value property is being updated via `EntityImpl#setPropertyInternal`, we do the following (roughly):
```java
entry.disableTracking(this, oldValue);
entry.value = value;
entry.enableTracking(this);
```
The problem arises when `oldValue == value`, i.e. `value` is the same collection instance that's already been set in the entity. If this collection already has updates, then we're gonna just lose them when calling `disableTracking`. This PR adds a unit test that checks this scenario and a fix that simply skips the update if  `oldValue == value`.

We have a Slack chat for contributors. If you wish to join, please
read [this article](https://youtrack.jetbrains.com/articles/YTDB-A-5/Slack-with-developers-for-contributors).
