### PR TITLE
Throwing ConcurrentModificationException when updating a deleted record

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/api/exception/ConcurrentModificationException.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/api/exception/ConcurrentModificationException.java
@@ -104,18 +104,29 @@ public class ConcurrentModificationException extends NeedRetryException
       int recordOperation, RID rid, int databaseVersion, int recordVersion) {
     final var operation = RecordOperation.getName(recordOperation);
 
-    var sb =
-        "Cannot "
-            + operation
-            + " the record "
-            + rid
-            + " because the version is not the latest. Probably you are "
-            + operation.toLowerCase(Locale.ENGLISH).substring(0, operation.length() - 1)
-            + "ing an old record or it has been modified by another user (db=v"
-            + databaseVersion
-            + " your=v"
-            + recordVersion
-            + ")";
-    return sb;
+    final var sb =
+        new StringBuilder()
+            .append("Cannot ").append(operation)
+            .append(" the record ").append(rid)
+            .append(" because ");
+
+    if (databaseVersion < 0) {
+      sb.append("it does not exist in the database.");
+    } else {
+      sb.append("the version is not the latest.");
+    }
+
+    sb.append(" Probably you are ")
+        .append(operation.toLowerCase(Locale.ENGLISH), 0, operation.length() - 1).append("ing ");
+
+    if (databaseVersion < 0) {
+      sb.append("a record that has been deleted by another user (your=v").append(recordVersion)
+          .append(")");
+    } else {
+      sb.append("an old record or it has been modified by another user (db=v")
+          .append(databaseVersion).append(" your=v").append(recordVersion).append(")");
+    }
+
+    return sb.toString();
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/storage/impl/local/AbstractStorage.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/storage/impl/local/AbstractStorage.java
@@ -4187,18 +4187,11 @@ public abstract class AbstractStorage
     try {
       final var ppos =
           collection.getPhysicalPosition(new PhysicalPosition(rid.getCollectionPosition()));
-      if (ppos == null) {
-        throw new RecordNotFoundException(name,
-            rid, "Cannot update record "
-            + rid
-            + " since the position is invalid in database '"
-            + name
-            + '\'');
-      }
 
-      if (version != ppos.recordVersion) {
-        throw new ConcurrentModificationException(name, rid, ppos.recordVersion, version,
-            RecordOperation.UPDATED);
+      if (ppos == null || ppos.recordVersion != version) {
+        final var dbVersion = ppos == null ? -1 : ppos.recordVersion;
+        throw new ConcurrentModificationException(
+            name, rid, dbVersion, version, RecordOperation.UPDATED);
       }
 
       ppos.recordVersion = version + 1;


### PR DESCRIPTION
Now we will throw a ConcurrentModificationError when trying to update a record that's been deleted in a parallel transaction.

We have a Slack chat for contributors. If you wish to join, please read [this article](https://youtrack.jetbrains.com/articles/YTDB-A-5/Slack-with-developers-for-contributors).
