### PR TITLE
Allowing colon in property names

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaShared.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaShared.java
@@ -148,7 +148,7 @@ public abstract class SchemaShared implements CloseableInStorage {
 
     for (var i = 0; i < nameSize; ++i) {
       final var c = iName.charAt(i);
-      if (c == ':' || c == ',' || c == ';' || c == ' ' || c == '=')
+      if (c == ',' || c == ';' || c == ' ' || c == '=')
       // INVALID CHARACTER
       {
         return c;

--- a/tests/src/test/java/com/jetbrains/youtrack/db/auto/CRUDDocumentPhysicalTest.java
+++ b/tests/src/test/java/com/jetbrains/youtrack/db/auto/CRUDDocumentPhysicalTest.java
@@ -422,7 +422,7 @@ public class CRUDDocumentPhysicalTest extends BaseDBTest {
         transaction -> {
           try {
             EntityImpl doc = session.newInstance();
-            doc.setProperty("a:b", 10);
+            doc.setProperty("a;b", 10);
             fail();
           } catch (IllegalArgumentException e) {
             Assert.assertTrue(true);


### PR DESCRIPTION
Allowing property names like `ab:c`, but not `:abc`.

We have a Slack chat for contributors. If you wish to join, please read [this article](https://youtrack.jetbrains.com/articles/YTDB-A-5/Slack-with-developers-for-contributors).
