### PR TITLE
DatabaseImport backward compatibility & graph structure support

### DIFF
--- a/client/src/main/java/com/jetbrains/youtrack/db/internal/client/remote/YouTrackDBRemote.java
+++ b/client/src/main/java/com/jetbrains/youtrack/db/internal/client/remote/YouTrackDBRemote.java
@@ -258,7 +258,7 @@ public class YouTrackDBRemote implements YouTrackDBInternal {
   public Map<String, Object> getServerInfo(String username, String password) {
     var request = new ServerInfoRequest();
     var response = connectAndSend(null, username, password, request);
-    return JSONSerializerJackson.mapFromJson(response.getResult());
+    return JSONSerializerJackson.INSTANCE.mapFromJson(response.getResult());
   }
 
   public String getGlobalConfiguration(

--- a/client/src/main/java/com/jetbrains/youtrack/db/internal/client/remote/metadata/schema/SchemaClassRemote.java
+++ b/client/src/main/java/com/jetbrains/youtrack/db/internal/client/remote/metadata/schema/SchemaClassRemote.java
@@ -231,7 +231,7 @@ public class SchemaClassRemote extends SchemaClassImpl {
     }
 
     if (metadata != null) {
-      queryBuilder.append(" metadata ").append(JSONSerializerJackson.mapToJson(metadata));
+      queryBuilder.append(" metadata ").append(JSONSerializerJackson.INSTANCE.mapToJson(metadata));
     }
 
     session.execute(queryBuilder.toString()).close();
@@ -378,7 +378,7 @@ public class SchemaClassRemote extends SchemaClassImpl {
 
   @Override
   protected void setSuperClassesInternal(DatabaseSessionInternal session,
-      final List<SchemaClassImpl> classes) {
+      final List<SchemaClassImpl> classes, boolean validateIndexes) {
     List<SchemaClassImpl> newSuperClasses = new ArrayList<SchemaClassImpl>();
     SchemaClassImpl cls;
     for (var superClass : classes) {
@@ -400,13 +400,14 @@ public class SchemaClassRemote extends SchemaClassImpl {
       toRemove.removeBaseClassInternal(session, this);
     }
     for (var addTo : toAddList) {
-      addTo.addBaseClass(session, this);
+      addTo.addBaseClass(session, this, validateIndexes);
     }
     superClasses.clear();
     superClasses.addAll(newSuperClasses);
   }
 
   @Override
-  protected void addCollectionIdToIndexes(DatabaseSessionInternal session, int iId) {
+  protected void addCollectionIdToIndexes(DatabaseSessionInternal session, int iId,
+      boolean requireEmpty) {
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseDocumentTx.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseDocumentTx.java
@@ -55,6 +55,7 @@ import com.jetbrains.youtrack.db.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrack.db.internal.core.record.impl.EdgeInternal;
 import com.jetbrains.youtrack.db.internal.core.record.impl.EntityImpl;
 import com.jetbrains.youtrack.db.internal.core.record.impl.RecordBytes;
+import com.jetbrains.youtrack.db.internal.core.record.impl.StatefullEdgeEntityImpl;
 import com.jetbrains.youtrack.db.internal.core.security.SecurityUser;
 import com.jetbrains.youtrack.db.internal.core.serialization.serializer.binary.BinarySerializerFactory;
 import com.jetbrains.youtrack.db.internal.core.serialization.serializer.record.RecordSerializer;
@@ -598,6 +599,12 @@ public class DatabaseDocumentTx implements DatabaseSessionInternal {
   public StatefulEdge newStatefulEdge(Vertex from, Vertex to, String type) {
     checkOpenness();
     return internal.newStatefulEdge(from, to, type);
+  }
+
+  @Override
+  public StatefullEdgeEntityImpl newStatefulEdgeInternal(String className) {
+    checkOpenness();
+    return internal.newStatefulEdgeInternal(className);
   }
 
   @Override

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
@@ -1440,13 +1440,13 @@ public abstract class DatabaseSessionAbstract<IM extends IndexManagerAbstract> e
   @Override
   public <T extends DBRecord> T createOrLoadRecordFromJson(String json) {
     assert assertIfNotActive();
-    return (T) JSONSerializerJackson.fromString(this, json);
+    return (T) JSONSerializerJackson.INSTANCE.fromString(this, json);
   }
 
   @Override
   public Entity createOrLoadEntityFromJson(String json) {
     assert assertIfNotActive();
-    var result = JSONSerializerJackson.fromString(this, json);
+    var result = JSONSerializerJackson.INSTANCE.fromString(this, json);
 
     if (result instanceof Entity) {
       return (Entity) result;
@@ -1510,7 +1510,8 @@ public abstract class DatabaseSessionAbstract<IM extends IndexManagerAbstract> e
     return vertex;
   }
 
-  private StatefullEdgeEntityImpl newStatefulEdgeInternal(final String className) {
+  @Override
+  public StatefullEdgeEntityImpl newStatefulEdgeInternal(final String className) {
     var cls = getMetadata().getImmutableSchemaSnapshot().getClass(className);
     if (cls == null) {
       throw new IllegalArgumentException("Class " + className + " not found");

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionInternal.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionInternal.java
@@ -66,6 +66,7 @@ import com.jetbrains.youtrack.db.internal.core.metadata.security.Token;
 import com.jetbrains.youtrack.db.internal.core.record.RecordAbstract;
 import com.jetbrains.youtrack.db.internal.core.record.impl.EdgeInternal;
 import com.jetbrains.youtrack.db.internal.core.record.impl.EntityImpl;
+import com.jetbrains.youtrack.db.internal.core.record.impl.StatefullEdgeEntityImpl;
 import com.jetbrains.youtrack.db.internal.core.security.SecurityUser;
 import com.jetbrains.youtrack.db.internal.core.serialization.serializer.binary.BinarySerializerFactory;
 import com.jetbrains.youtrack.db.internal.core.serialization.serializer.record.RecordSerializer;
@@ -1019,6 +1020,8 @@ public interface DatabaseSessionInternal extends DatabaseSession {
    * @return the edge
    */
   StatefulEdge newStatefulEdge(Vertex from, Vertex to, String type);
+
+  StatefullEdgeEntityImpl newStatefulEdgeInternal(String className);
 
   /**
    * Creates a new lightweight edge of provided type (class). Provided class should be an abstract

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/EntityFieldWalker.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/EntityFieldWalker.java
@@ -19,9 +19,9 @@
  */
 package com.jetbrains.youtrack.db.internal.core.db;
 
-import com.jetbrains.youtrack.db.api.schema.PropertyType;
 import com.jetbrains.youtrack.db.api.schema.SchemaClass;
 import com.jetbrains.youtrack.db.internal.common.collection.MultiValue;
+import com.jetbrains.youtrack.db.internal.core.metadata.schema.PropertyTypeInternal;
 import com.jetbrains.youtrack.db.internal.core.metadata.schema.SchemaImmutableClass;
 import com.jetbrains.youtrack.db.internal.core.record.impl.EntityImpl;
 import java.util.Collections;
@@ -38,17 +38,17 @@ import java.util.Set;
  * collections also will be visited.
  *
  * <p>Fields values can be updated/converted too. If method {@link
- * EntityPropertiesVisitor#visitField(DatabaseSessionInternal, PropertyType, PropertyType, Object)}
+ * EntityPropertiesVisitor#visitField(DatabaseSessionInternal, PropertyTypeInternal, PropertyTypeInternal, Object)}
  * will return new value original value will be updated but returned result will not be visited by
  * {@link EntityPropertiesVisitor} instance.
  *
  * <p>If currently processed value is collection or map of embedded documents or embedded entity
- * itself then method {@link EntityPropertiesVisitor#goDeeper(PropertyType, PropertyType, Object)}
+ * itself then method {@link EntityPropertiesVisitor#goDeeper(PropertyTypeInternal, PropertyTypeInternal, Object)}
  * is called, if it returns false then this collection will not be visited by
  * {@link EntityPropertiesVisitor} instance.
  *
  * <p>Fields will be visited till method
- * {@link EntityPropertiesVisitor#goFurther(PropertyType, PropertyType, Object, Object)} returns
+ * {@link EntityPropertiesVisitor#goFurther(PropertyTypeInternal, PropertyTypeInternal, Object, Object)} returns
  * true.
  */
 public class EntityFieldWalker {
@@ -86,20 +86,20 @@ public class EntityFieldWalker {
 
     final var updateMode = fieldWalker.updateMode();
 
-    SchemaImmutableClass result = null;
+    SchemaImmutableClass result;
     result = entity.getImmutableSchemaClass(session);
     final SchemaClass clazz = result;
-    for (var fieldName : entity.propertyNames()) {
+    for (var fieldName : entity.getPropertyNamesInternal(false, false)) {
 
-      final var concreteType = entity.getPropertyType(fieldName);
+      final var concreteType = entity.getPropertyTypeInternal(fieldName);
       var fieldType = concreteType;
 
-      PropertyType linkedType = null;
+      PropertyTypeInternal linkedType = null;
       if (fieldType == null && clazz != null) {
         var property = clazz.getProperty(fieldName);
         if (property != null) {
-          fieldType = property.getType();
-          linkedType = property.getLinkedType();
+          fieldType = PropertyTypeInternal.convertFromPublicType(property.getType());
+          linkedType = PropertyTypeInternal.convertFromPublicType(property.getLinkedType());
         }
       }
 
@@ -120,21 +120,20 @@ public class EntityFieldWalker {
       // 3. entity is not not embedded.
       if (!updated
           && fieldValue != null
-          && !(PropertyType.LINK == fieldType
-          || PropertyType.LINKBAG == fieldType
-          || PropertyType.LINKLIST == fieldType
-          || PropertyType.LINKSET == fieldType
-          || PropertyType.LINKMAP == fieldType)) {
+          && !(PropertyTypeInternal.LINK == fieldType
+          || PropertyTypeInternal.LINKBAG == fieldType
+          || PropertyTypeInternal.LINKLIST == fieldType
+          || PropertyTypeInternal.LINKSET == fieldType
+          || PropertyTypeInternal.LINKMAP == fieldType)) {
         if (fieldWalker.goDeeper(fieldType, linkedType, fieldValue)) {
           if (fieldValue instanceof Map) {
             walkMap(session, (Map) fieldValue, fieldType, fieldWalker, walked);
           } else if (fieldValue instanceof EntityImpl e) {
-            if (PropertyType.EMBEDDED.equals(fieldType) || e.isEmbedded()) {
-              var fEntity = (EntityImpl) fieldValue;
-              if (fEntity.isUnloaded()) {
+            if (PropertyTypeInternal.EMBEDDED.equals(fieldType) || e.isEmbedded()) {
+              if (e.isUnloaded()) {
                 throw new IllegalStateException("Entity is unloaded");
               }
-              walkDocument(session, fEntity, fieldWalker);
+              walkDocument(session, e, fieldWalker);
             }
           } else if (MultiValue.isIterable(fieldValue)) {
             walkIterable(
@@ -160,14 +159,14 @@ public class EntityFieldWalker {
   private void walkMap(
       DatabaseSessionInternal session,
       Map map,
-      PropertyType fieldType,
+      PropertyTypeInternal fieldType,
       EntityPropertiesVisitor fieldWalker,
       Set<EntityImpl> walked) {
     for (var value : map.values()) {
       if (value instanceof EntityImpl entity) {
         // only embedded documents are walked
-        if (PropertyType.EMBEDDEDMAP.equals(fieldType) || entity.isEmbedded()) {
-          walkDocument(session, (EntityImpl) value, fieldWalker, walked);
+        if (PropertyTypeInternal.EMBEDDEDMAP.equals(fieldType) || entity.isEmbedded()) {
+          walkDocument(session, entity, fieldWalker, walked);
         }
       }
     }
@@ -176,16 +175,16 @@ public class EntityFieldWalker {
   private void walkIterable(
       DatabaseSessionInternal session,
       Iterable iterable,
-      PropertyType fieldType,
+      PropertyTypeInternal fieldType,
       EntityPropertiesVisitor fieldWalker,
       Set<EntityImpl> walked) {
     for (var value : iterable) {
       if (value instanceof EntityImpl entity) {
         // only embedded documents are walked
-        if (PropertyType.EMBEDDEDLIST.equals(fieldType)
-            || PropertyType.EMBEDDEDSET.equals(fieldType)
+        if (PropertyTypeInternal.EMBEDDEDLIST.equals(fieldType)
+            || PropertyTypeInternal.EMBEDDEDSET.equals(fieldType)
             || entity.isEmbedded()) {
-          walkDocument(session, (EntityImpl) value, fieldWalker, walked);
+          walkDocument(session, entity, fieldWalker, walked);
         }
       }
     }
@@ -196,9 +195,9 @@ public class EntityFieldWalker {
       String fieldName,
       Object fieldValue,
       Object newValue,
-      PropertyType concreteType) {
+      PropertyTypeInternal concreteType) {
     if (fieldValue != newValue) {
-      entity.setProperty(fieldName, newValue, concreteType);
+      entity.setPropertyInternal(fieldName, newValue, concreteType);
       return true;
     }
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/EntityPropertiesVisitor.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/EntityPropertiesVisitor.java
@@ -20,7 +20,7 @@
 
 package com.jetbrains.youtrack.db.internal.core.db;
 
-import com.jetbrains.youtrack.db.api.schema.PropertyType;
+import com.jetbrains.youtrack.db.internal.core.metadata.schema.PropertyTypeInternal;
 
 /**
  * Is used in together with {@link EntityFieldWalker} to visit all fields of current document.
@@ -38,8 +38,8 @@ public interface EntityPropertiesVisitor {
    * @return New value of this field. If the same value is returned document content will not be
    * changed.
    */
-  Object visitField(DatabaseSessionInternal db, PropertyType type, PropertyType linkedType,
-      Object value);
+  Object visitField(DatabaseSessionInternal db, PropertyTypeInternal type,
+      PropertyTypeInternal linkedType, Object value);
 
   /**
    * Indicates whether we continue to visit document fields after current one or should stop fields
@@ -50,11 +50,12 @@ public interface EntityPropertiesVisitor {
    *                   schema.
    * @param value      Field value.
    * @param newValue   New value returned by
-   *                   {@link #visitField(DatabaseSessionInternal, PropertyType, PropertyType,
+   *                   {@link #visitField(DatabaseSessionInternal, PropertyTypeInternal, PropertyTypeInternal,
    *                   Object)} method.
    * @return If false document processing will be stopped.
    */
-  boolean goFurther(PropertyType type, PropertyType linkedType, Object value, Object newValue);
+  boolean goFurther(PropertyTypeInternal type, PropertyTypeInternal linkedType, Object value,
+      Object newValue);
 
   /**
    * If currently processed value is collection or map of embedded documents or embedded document
@@ -67,11 +68,11 @@ public interface EntityPropertiesVisitor {
    * @param value      Field value.
    * @return If false currently processed collection of embedded documents will not be visited.
    */
-  boolean goDeeper(PropertyType type, PropertyType linkedType, Object value);
+  boolean goDeeper(PropertyTypeInternal type, PropertyTypeInternal linkedType, Object value);
 
   /**
    * @return If false value returned by method
-   * {@link #visitField(DatabaseSessionInternal, PropertyType, PropertyType, Object)} will not be
+   * {@link #visitField(DatabaseSessionInternal, PropertyTypeInternal, PropertyTypeInternal, Object)} will not be
    * taken in account and field value will not be updated.
    */
   boolean updateMode();

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/YouTrackDBImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/YouTrackDBImpl.java
@@ -378,7 +378,7 @@ public class YouTrackDBImpl implements YouTrackDB {
     var jsonMap = new HashMap<String, Object>();
     jsonMap.put("config", configMap);
 
-    var json = JSONSerializerJackson.mapToJson(jsonMap);
+    var json = JSONSerializerJackson.INSTANCE.mapToJson(jsonMap);
     queryString.append(" ").append(json);
   }
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseExport.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseExport.java
@@ -58,7 +58,7 @@ import java.util.zip.GZIPOutputStream;
  */
 public class DatabaseExport extends DatabaseImpExpAbstract {
 
-  public static final int EXPORTER_VERSION = 13;
+  public static final int EXPORTER_VERSION = 14;
 
   protected JsonGenerator jsonGenerator;
   protected long recordExported;
@@ -448,7 +448,7 @@ public class DatabaseExport extends DatabaseImpExpAbstract {
       final var metadata = index.getMetadata();
       if (metadata != null) {
         jsonGenerator.writeFieldName("metadata");
-        JSONSerializerJackson.serializeEmbeddedMap(session, jsonGenerator, metadata, null);
+        JSONSerializerJackson.INSTANCE.serializeEmbeddedMap(session, jsonGenerator, metadata, null);
       }
 
       jsonGenerator.writeEndObject();
@@ -597,7 +597,7 @@ public class DatabaseExport extends DatabaseImpExpAbstract {
     if (rec != null) {
       try {
         final var format = "rid,version,class,type,keepTypes,internal,markEmbeddedEntities";
-        JSONSerializerJackson.recordToJson(session, rec, jsonGenerator, format);
+        JSONSerializerJackson.INSTANCE.recordToJson(session, rec, jsonGenerator, format);
 
         recordExported++;
         recordNum++;

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseImport.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/DatabaseImport.java
@@ -24,10 +24,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jetbrains.youtrack.db.api.DatabaseSession.STATUS;
 import com.jetbrains.youtrack.db.api.config.GlobalConfiguration;
 import com.jetbrains.youtrack.db.api.exception.BaseException;
-import com.jetbrains.youtrack.db.api.exception.ConfigurationException;
 import com.jetbrains.youtrack.db.api.exception.DatabaseException;
+import com.jetbrains.youtrack.db.api.record.Edge;
 import com.jetbrains.youtrack.db.api.record.Entity;
 import com.jetbrains.youtrack.db.api.record.RID;
+import com.jetbrains.youtrack.db.api.record.Vertex;
 import com.jetbrains.youtrack.db.api.schema.PropertyType;
 import com.jetbrains.youtrack.db.api.schema.Schema;
 import com.jetbrains.youtrack.db.api.schema.SchemaClass;
@@ -48,9 +49,9 @@ import com.jetbrains.youtrack.db.internal.core.id.RecordId;
 import com.jetbrains.youtrack.db.internal.core.index.IndexDefinition;
 import com.jetbrains.youtrack.db.internal.core.index.IndexManagerEmbedded;
 import com.jetbrains.youtrack.db.internal.core.index.SimpleKeyIndexDefinition;
+import com.jetbrains.youtrack.db.internal.core.metadata.MetadataDefault;
 import com.jetbrains.youtrack.db.internal.core.metadata.function.Function;
 import com.jetbrains.youtrack.db.internal.core.metadata.schema.PropertyTypeInternal;
-import com.jetbrains.youtrack.db.internal.core.metadata.schema.SchemaClassEmbedded;
 import com.jetbrains.youtrack.db.internal.core.metadata.schema.SchemaClassImpl;
 import com.jetbrains.youtrack.db.internal.core.metadata.schema.SchemaClassInternal;
 import com.jetbrains.youtrack.db.internal.core.metadata.security.Identity;
@@ -77,6 +78,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.text.ParseException;
 import java.util.AbstractList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -87,6 +89,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,18 +107,17 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
   private final Map<SchemaProperty, String> linkedClasses = new HashMap<>();
   private final Map<String, List<String>> superClasses = new HashMap<>();
   private JSONReader jsonReader;
+  private JSONSerializerJackson jsonSerializer = JSONSerializerJackson.IMPORT_INSTANCE;
   private int exporterVersion = -1;
-  private RID schemaRecordId;
-  private RID indexMgrRecordId;
 
   private boolean deleteRIDMapping = true;
 
-  private boolean preserveCollectionIDs = true;
   private boolean migrateLinks = true;
   private boolean rebuildIndexes = true;
 
   private final Set<String> indexesToRebuild = new HashSet<>();
 
+  private static final int COLLECTION_NOT_FOUND_VALUE = -2;
   private final Int2IntOpenHashMap collectionToCollectionMapping = new Int2IntOpenHashMap();
 
   private int maxRidbagStringSizeBeforeLazyImport = 100_000_000;
@@ -127,7 +129,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       throws IOException {
     super(database, fileName, outputListener);
     validateSessionImpl();
-    collectionToCollectionMapping.defaultReturnValue(-2);
+    collectionToCollectionMapping.defaultReturnValue(COLLECTION_NOT_FOUND_VALUE);
     // TODO: check unclosed stream?
     final var bufferedInputStream =
         new BufferedInputStream(new FileInputStream(this.fileName));
@@ -149,7 +151,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       throws IOException {
     super(database, "streaming", outputListener);
     validateSessionImpl();
-    collectionToCollectionMapping.defaultReturnValue(-2);
+    collectionToCollectionMapping.defaultReturnValue(COLLECTION_NOT_FOUND_VALUE);
     createJsonReaderDefaultListenerAndDeclareIntent(outputListener, inputStream);
   }
 
@@ -185,21 +187,16 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
   protected void parseSetting(final String option, final List<String> items) {
     if (option.equalsIgnoreCase("-deleteRIDMapping")) {
       deleteRIDMapping = Boolean.parseBoolean(items.getFirst());
+    } else if (option.equalsIgnoreCase("-migrateLinks")) {
+      migrateLinks = Boolean.parseBoolean(items.getFirst());
+    } else if (option.equalsIgnoreCase("-rebuildIndexes")) {
+      rebuildIndexes = Boolean.parseBoolean(items.getFirst());
+    } else if (option.equalsIgnoreCase("-backwardCompatMode")) {
+      jsonSerializer = Boolean.parseBoolean(items.getFirst()) ?
+          JSONSerializerJackson.IMPORT_BACKWARDS_COMPAT_INSTANCE :
+          JSONSerializerJackson.IMPORT_INSTANCE;
     } else {
-      if (option.equalsIgnoreCase("-preserveCollectionIDs")) {
-        preserveCollectionIDs = Boolean.parseBoolean(items.getFirst());
-      } else {
-
-        if (option.equalsIgnoreCase("-migrateLinks")) {
-          migrateLinks = Boolean.parseBoolean(items.getFirst());
-        } else {
-          if (option.equalsIgnoreCase("-rebuildIndexes")) {
-            rebuildIndexes = Boolean.parseBoolean(items.getFirst());
-          } else {
-            super.parseSetting(option, items);
-          }
-        }
-      }
+      super.parseSetting(option, items);
     }
   }
 
@@ -231,33 +228,18 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       while (jsonReader.hasNext() && jsonReader.lastChar() != '}') {
         final var tag = jsonReader.readString(JSONReader.FIELD_ASSIGNMENT);
 
-        if (tag.equals("info")) {
-          importInfo();
-        } else {
-          if (tag.equals("collections")) {
+        switch (tag) {
+          case "info" -> importInfo();
+          case "collections", "clusters" -> {
             importCollections();
             collectionsImported = true;
-          } else {
-            if (tag.equals("schema")) {
-              importSchema(collectionsImported);
-            } else {
-              if (tag.equals("records")) {
-                importRecords(beforeImportSchemaSnapshot);
-              } else {
-                if (tag.equals("indexes")) {
-                  importIndexes();
-                } else {
-
-                  if (tag.equals("brokenRids")) {
-                    processBrokenRids();
-                  } else {
-                    throw new DatabaseImportException(
-                        "Invalid format. Found unsupported tag '" + tag + "'");
-                  }
-                }
-              }
-            }
           }
+          case "schema" -> importSchema(collectionsImported);
+          case "records" -> importRecords(beforeImportSchemaSnapshot);
+          case "indexes" -> importIndexes();
+          case "brokenRids" -> processBrokenRids();
+          default -> throw new DatabaseImportException(
+              "Invalid format. Found unsupported tag '" + tag + "'");
         }
       }
       if (rebuildIndexes) {
@@ -431,29 +413,15 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       final var fieldName = jsonReader.readString(JSONReader.FIELD_ASSIGNMENT);
       if (fieldName.equals("exporter-version")) {
         exporterVersion = jsonReader.readInteger(JSONReader.NEXT_IN_OBJECT);
-      } else {
-        if (fieldName.equals("schemaRecordId")) {
-          schemaRecordId = new RecordId(jsonReader.readString(JSONReader.NEXT_IN_OBJECT));
-        } else {
-          if (fieldName.equals("indexMgrRecordId")) {
-            indexMgrRecordId = new RecordId(jsonReader.readString(JSONReader.NEXT_IN_OBJECT));
-          } else {
-            jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
-          }
+        if (exporterVersion < 14) {
+          jsonSerializer = JSONSerializerJackson.IMPORT_BACKWARDS_COMPAT_INSTANCE;
         }
+      } else {
+        jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
       }
     }
     jsonReader.readNext(JSONReader.COMMA_SEPARATOR);
 
-    if (schemaRecordId == null) {
-      schemaRecordId =
-          new RecordId(session.getStorageInfo().getConfiguration().getSchemaRecordId());
-    }
-
-    if (indexMgrRecordId == null) {
-      indexMgrRecordId =
-          new RecordId(session.getStorageInfo().getConfiguration().getIndexMgrRecordId());
-    }
 
     listener.onMessage("OK");
   }
@@ -559,7 +527,8 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       jsonReader.readNext(JSONReader.FIELD_ASSIGNMENT);
     }
 
-    if (jsonReader.getValue().equals("\"blob-collections\"")) {
+    if (jsonReader.getValue().equals("\"blob-collections\"") ||
+        jsonReader.getValue().equals("\"blob-clusters\"")) {
       var blobCollectionIds = jsonReader.readString(JSONReader.END_COLLECTION, true).trim();
       blobCollectionIds = blobCollectionIds.substring(1, blobCollectionIds.length() - 1);
 
@@ -568,7 +537,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
         for (var i :
             StringSerializerHelper.split(
                 blobCollectionIds, StringSerializerHelper.RECORD_SEPARATOR)) {
-          var collection = Integer.parseInt(i);
+          var collection = Integer.parseInt(i.trim());
           if (!ArrayUtils.contains(session.getBlobCollectionIds(), collection)) {
             var name = session.getCollectionNameById(collection);
             session.addBlobCollection(name);
@@ -585,6 +554,17 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
     long classImported = 0;
 
     try {
+
+      // creating V and E classes ahead of time, because they have to exist
+      // before we start creating other vertex or edge classes.
+      // we tried to fix this by making the export tool write these classes first,
+      // but if the dump was created by an older version of the export tool,
+      // it won't work.
+      final var schema = session.getMetadata().getSchema();
+      final var vertexClass = schema.existsClass(Vertex.CLASS_NAME) ?
+          schema.getClass(Vertex.CLASS_NAME) : schema.createClass(Vertex.CLASS_NAME);
+      final var edgeClass = schema.existsClass(Edge.CLASS_NAME) ?
+          schema.getClass(Edge.CLASS_NAME) : schema.createClass(Edge.CLASS_NAME);
       do {
         jsonReader.readNext(JSONReader.BEGIN_OBJECT);
         var className =
@@ -593,15 +573,25 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
                 .checkContent("\"name\"")
                 .readString(JSONReader.COMMA_SEPARATOR);
 
-        var collectionIdsStr = jsonReader
+        final var collectionIdsTag =
+            exporterVersion >= 14 ? "\"collection-ids\"" : "\"cluster-ids\"";
+        final var collectionIdsStr = jsonReader
             .readNext(JSONReader.FIELD_ASSIGNMENT)
-            .checkContent("\"collection-ids\"")
+            .checkContent(collectionIdsTag)
             .readString(JSONReader.END_COLLECTION, true)
             .trim();
 
-        var classCollectionIds =
+        final var originalCollectionIds =
             StringSerializerHelper.splitIntArray(
                 collectionIdsStr.substring(1, collectionIdsStr.length() - 1));
+
+        // it's important to use previously created collections here because later the indexes
+        // are created on collections (not on classes).
+        final var newCollectionIds =
+            Arrays.stream(originalCollectionIds)
+                .map(collectionToCollectionMapping::get)
+                .filter(cid -> cid != COLLECTION_NOT_FOUND_VALUE)
+                .toArray();
 
         jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
         if (className.contains(".")) {
@@ -650,7 +640,8 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
               while (jsonReader.lastChar() != ']') {
                 jsonReader.readNext(JSONReader.NEXT_IN_ARRAY);
 
-                final var clsName = IOUtils.getStringContent(jsonReader.getValue());
+                final var clsName =
+                    IOUtils.getStringContent(StringUtils.trim(jsonReader.getValue()));
 
                 if (SchemaClass.VERTEX_CLASS_NAME.equals(clsName)) {
                   isVertex = true;
@@ -673,11 +664,16 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
 
               while (jsonReader.lastChar() != ']') {
                 final var pRaw = jsonReader.readNext(JSONReader.NEXT_IN_ARRAY).getValue();
-                final var pMap = JSONSerializerJackson.mapFromJson(pRaw);
-                propertiesRaw.add(pMap);
+                if (StringUtils.isNotBlank(pRaw)) {
+                  final var pMap = jsonSerializer.mapFromJson(pRaw);
+                  propertiesRaw.add(pMap);
+                }
               }
               jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
             }
+            case "\"cluster-selection\"" ->
+              // ignoring old property
+                jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
             case "\"customFields\"" -> {
               customFields = importCustomFields();
             }
@@ -689,7 +685,6 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
               "Class '" + className + "' cannot be both vertex and edge.");
         }
 
-        final var schema = session.getMetadata().getSchema();
         var cls = schema.getClass(className);
 
         if (cls != null) {
@@ -702,12 +697,13 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
             );
           }
         } else {
-          if (isVertex) {
-            cls = schema.createVertexClass(className);
-          } else if (isEdge) {
-            cls = schema.createEdgeClass(className);
-          } else if (collectionsImported) {
-            cls = schema.createClass(className, classCollectionIds);
+          if (collectionsImported) {
+            // other superclasses will be added later.
+            final var superClassesToAdd =
+                isVertex ? new SchemaClass[]{vertexClass} :
+                    isEdge ? new SchemaClass[]{edgeClass} :
+                        new SchemaClass[]{};
+            cls = schema.createClass(className, newCollectionIds, superClassesToAdd);
           } else if (className.equalsIgnoreCase("ORestricted")) {
             cls = schema.createAbstractClass(className);
           } else {
@@ -872,6 +868,14 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
 
       name = SchemaClassImpl.decodeClassName(name);
 
+      if (exporterVersion <= 13 && name != null &&
+          (name.equals("index") || name.equals("manindex") || name.equals("default"))) {
+        listener.onMessage(
+            "\nWARNING: collection '" + name + "' cannot be imported. It will be skipped.");
+        jsonReader.readNext(JSONReader.NEXT_IN_ARRAY);
+        continue;
+      }
+
       int collectionIdFromJson;
       if (exporterVersion < 9) {
         collectionIdFromJson =
@@ -908,58 +912,11 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       listener.onMessage(
           "\n- Creating collection " + (name != null ? "'" + name + "'" : "NULL") + "...");
 
-      var createdCollectionId = name != null ? session.getCollectionIdByName(name) : -1;
+      var createdCollectionId = name == null ? -1 : session.getCollectionIdByName(name);
       if (createdCollectionId == -1) {
-        // CREATE IT
-        if (!preserveCollectionIDs) {
-          createdCollectionId = session.addCollection(name);
-        } else {
-          if (getDatabase().getCollectionNameById(collectionIdFromJson) == null) {
-            createdCollectionId = session.addCollection(name, collectionIdFromJson, null);
-            assert createdCollectionId == collectionIdFromJson;
-          } else {
-            createdCollectionId = session.addCollection(name);
-            listener.onMessage(
-                "\n- WARNING collection with id " + collectionIdFromJson + " already exists");
-          }
-        }
+        createdCollectionId = session.addCollection(name);
       }
 
-      if (createdCollectionId != collectionIdFromJson) {
-        if (!preserveCollectionIDs) {
-          if (session.countCollectionElements(createdCollectionId - 1) == 0) {
-            listener.onMessage("Found previous version: migrating old collections...");
-            session.dropCollection(name);
-            session.addCollection("temp_" + createdCollectionId);
-            createdCollectionId = session.addCollection(name);
-          } else {
-            throw new ConfigurationException(
-                session.getDatabaseName(), "Imported collection '"
-                + name
-                + "' has id="
-                + createdCollectionId
-                + " different from the original: "
-                + collectionIdFromJson
-                + ". To continue the import drop the collection '"
-                + session.getCollectionNameById(createdCollectionId - 1)
-                + "' that has "
-                + session.countCollectionElements(createdCollectionId - 1)
-                + " records");
-          }
-        } else {
-
-          final var clazz =
-              session.getMetadata().getSchema().getClassByCollectionId(createdCollectionId);
-          if (clazz instanceof SchemaClassEmbedded) {
-            throw new DatabaseImportException(
-                "Can not drop collection with id " + createdCollectionId
-                    + " because it is used by class " + clazz.getName());
-          }
-
-          session.dropCollection(createdCollectionId);
-          createdCollectionId = session.addCollection(name, collectionIdFromJson, null);
-        }
-      }
       collectionToCollectionMapping.put(collectionIdFromJson, createdCollectionId);
 
       listener.onMessage(
@@ -1042,20 +999,21 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
         return null;
       }
       RawPair<RecordAbstract, RecordMetadata> parsed;
-      parsed = JSONSerializerJackson.fromStringWithMetadata(session, recordJson, null, true);
+      parsed = jsonSerializer.fromStringWithMetadata(session, recordJson, null, true);
       final var record = parsed.first();
       final var metadata = parsed.second();
       rid = record.getIdentity();
       originalRid = metadata.recordId();
 
+      if (exporterVersion <= 13 &&
+          record instanceof Entity entity &&
+          Role.CLASS_NAME.equals(entity.getSchemaClassName())) {
+        fixRoleRulesAndPolicies(entity.getEmbeddedMap("rules"));
+        fixRoleRulesAndPolicies(entity.getLinkMap("policies"));
+      }
+
       switch (metadata.entityType()) {
-        case SCHEMA_MANAGER -> {
-          recordsBeforeImport.remove(schemaRecordId);
-          record.delete();
-          rid = null;
-        }
-        case INDEX_MANAGER -> {
-          recordsBeforeImport.remove(indexMgrRecordId);
+        case SCHEMA_MANAGER, INDEX_MANAGER -> {
           record.delete();
           rid = null;
         }
@@ -1091,7 +1049,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
             } else {
 
               // parse it again, because we've removed it earlier
-              rid = JSONSerializerJackson
+              rid = jsonSerializer
                   .fromStringWithMetadata(session, recordJson, null, true)
                   .first()
                   .getIdentity();
@@ -1140,6 +1098,24 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
     }
 
     return rid;
+  }
+
+  private static <E> void fixRoleRulesAndPolicies(Map<String, E> roleRules) {
+    if (roleRules == null) {
+      return;
+    }
+
+    // replacing "cluster" with "collection"
+    for (var rule : new ArrayList<>(roleRules.entrySet())) {
+      if (rule.getKey().startsWith("database.cluster")) {
+        roleRules.remove(rule.getKey());
+        roleRules.put("database.collection" + rule.getKey().substring(16), rule.getValue());
+      } else if (rule.getKey().startsWith("database.systemclusters")) {
+        roleRules.remove(rule.getKey());
+        roleRules.put("database.systemcollections" + rule.getKey().substring(23),
+            rule.getValue());
+      }
+    }
   }
 
   private @Nullable EntityImpl findRelatedSystemRecord(
@@ -1202,6 +1178,7 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
     if (schema.getClass(EXPORT_IMPORT_CLASS_NAME) != null) {
       schema.dropClass(EXPORT_IMPORT_CLASS_NAME);
     }
+
     final var cls = schema.createClass(EXPORT_IMPORT_CLASS_NAME);
     cls.createProperty("key", PropertyType.STRING);
     cls.createProperty("value", PropertyType.STRING);
@@ -1218,8 +1195,18 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       // and then remove left overs
       final var recordsBeforeImport = new HashSet<RID>();
 
+      // just in case they are not in the internal collection (possibly redundant logic)
+      final var schemaRecordId =
+          new RecordId(session.getStorageInfo().getConfiguration().getSchemaRecordId());
+      final var indexMgrRecordId =
+          new RecordId(session.getStorageInfo().getConfiguration().getIndexMgrRecordId());
+
       session.executeInTx(transaction -> {
         for (final var collectionName : session.getCollectionNames()) {
+          if (collectionName.equals(MetadataDefault.COLLECTION_INTERNAL_NAME)) {
+            // don't want to mess with the internal collection
+            continue;
+          }
           var recordIterator = session.browseCollection(collectionName);
           while (recordIterator.hasNext()) {
             var identity = recordIterator.next().getIdentity();
@@ -1336,36 +1323,28 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
 
       while (jsonReader.lastChar() != '}') {
         final var fieldName = jsonReader.readString(JSONReader.FIELD_ASSIGNMENT);
-        if (fieldName.equals("name")) {
-          indexName = jsonReader.readString(JSONReader.NEXT_IN_OBJECT);
-        } else {
-          if (fieldName.equals("type")) {
-            indexType = jsonReader.readString(JSONReader.NEXT_IN_OBJECT);
-          } else {
-            if (fieldName.equals("algorithm")) {
-              indexAlgorithm = jsonReader.readString(JSONReader.NEXT_IN_OBJECT);
-            } else {
-              if (fieldName.equals("collectionsToIndex")) {
-                collectionsToIndex = importCollectionsToIndex();
-              } else {
-                if (fieldName.equals("definition")) {
-                  indexDefinition = importIndexDefinition(objectMapper);
-                  jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
-                } else {
-                  if (fieldName.equals("metadata")) {
-                    final var jsonMetadata = jsonReader.readString(JSONReader.END_OBJECT, true);
-                    metadata = objectMapper.readValue(jsonMetadata, typeRef);
-                  } else {
-                    if (fieldName.equals("engineProperties")) {
-                      jsonReader.readString(JSONReader.END_OBJECT, true);
-                      jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
-                    }
-                  }
-                }
-              }
+        switch (fieldName) {
+          case "name" -> indexName = jsonReader.readString(JSONReader.NEXT_IN_OBJECT);
+          case "type" -> indexType = jsonReader.readString(JSONReader.NEXT_IN_OBJECT);
+          case "algorithm" -> indexAlgorithm = jsonReader.readString(JSONReader.NEXT_IN_OBJECT);
+          case "collectionsToIndex", "clustersToIndex" ->
+              collectionsToIndex = importCollectionsToIndex();
+          case "definition" -> {
+            indexDefinition = importIndexDefinition(objectMapper);
+            jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
+          }
+          case "metadata" -> {
+            final var jsonMetadata = jsonReader.readString(JSONReader.END_OBJECT, true);
+            metadata = objectMapper.readValue(jsonMetadata, typeRef);
+          }
+          default -> {
+            if (fieldName.equals("engineProperties")) {
+              jsonReader.readString(JSONReader.END_OBJECT, true);
+              jsonReader.readNext(JSONReader.NEXT_IN_OBJECT);
             }
           }
         }
+
       }
       jsonReader.readNext(JSONReader.NEXT_IN_ARRAY);
 
@@ -1388,13 +1367,21 @@ public class DatabaseImport extends DatabaseImpExpAbstract {
       final IndexManagerEmbedded indexManager,
       int numberOfCreatedIndexes,
       final String indexName,
-      final String indexType,
-      final String indexAlgorithm,
+      String indexType,
+      String indexAlgorithm,
       final Set<String> collectionsToIndex,
       IndexDefinition indexDefinition,
       final Map<String, Object> metadata) {
     if (indexName == null) {
       throw new IllegalArgumentException("Index name is missing");
+    }
+
+    if ("CELL_BTREE".equals(indexAlgorithm) || "HASH_INDEX".equals(indexAlgorithm)) {
+      indexAlgorithm = "BTREE";
+    }
+
+    if ("UNIQUE_HASH_INDEX".equals(indexType)) {
+      indexType = "UNIQUE";
     }
 
     // drop automatically created indexes

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/importer/LinksRewriter.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/tool/importer/LinksRewriter.java
@@ -1,8 +1,8 @@
 package com.jetbrains.youtrack.db.internal.core.db.tool.importer;
 
-import com.jetbrains.youtrack.db.api.schema.PropertyType;
 import com.jetbrains.youtrack.db.internal.core.db.DatabaseSessionInternal;
 import com.jetbrains.youtrack.db.internal.core.db.EntityPropertiesVisitor;
+import com.jetbrains.youtrack.db.internal.core.metadata.schema.PropertyTypeInternal;
 import javax.annotation.Nullable;
 
 /**
@@ -18,7 +18,9 @@ public final class LinksRewriter implements EntityPropertiesVisitor {
 
   @Nullable
   @Override
-  public Object visitField(DatabaseSessionInternal db, PropertyType type, PropertyType linkedType,
+  public Object visitField(DatabaseSessionInternal db,
+      PropertyTypeInternal type,
+      PropertyTypeInternal linkedType,
       Object value) {
     final var valuesConverter =
         ImportConvertersFactory.INSTANCE.getConverter(value, converterData);
@@ -39,13 +41,14 @@ public final class LinksRewriter implements EntityPropertiesVisitor {
   }
 
   @Override
-  public boolean goFurther(PropertyType type, PropertyType linkedType, Object value,
+  public boolean goFurther(PropertyTypeInternal type, PropertyTypeInternal linkedType, Object value,
       Object newValue) {
     return true;
   }
 
   @Override
-  public boolean goDeeper(PropertyType type, PropertyType linkedType, Object value) {
+  public boolean goDeeper(PropertyTypeInternal type, PropertyTypeInternal linkedType,
+      Object value) {
     return true;
   }
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/Index.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/Index.java
@@ -337,9 +337,11 @@ public interface Index extends Comparable<Index> {
    *
    * @param transaction
    * @param collectionName Collection to add.
+   * @param requireEmpty Whether the collection has to be empty.
    * @return Current index instance.
    */
-  Index addCollection(FrontendTransaction transaction, final String collectionName);
+  Index addCollection(FrontendTransaction transaction, final String collectionName,
+      boolean requireEmpty);
 
   /**
    * Remove given collection from the list of collections that should be automatically indexed.

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/IndexAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/IndexAbstract.java
@@ -654,16 +654,20 @@ public abstract class IndexAbstract implements Index {
     }
   }
 
-  public IndexAbstract addCollection(FrontendTransaction transaction, final String collectionName) {
+  public IndexAbstract addCollection(FrontendTransaction transaction, final String collectionName,
+      boolean requireEmpty) {
     acquireExclusiveLock();
     try {
       var session = transaction.getDatabaseSession();
       if (collectionsToIndex.add(collectionName)) {
-        // INDEX SINGLE COLLECTION
-        var collectionId = session.getCollectionIdByName(collectionName);
-        if (session.countCollectionElements(collectionId) > 0) {
-          throw new IndexException("Collection " + collectionName
-              + " is not empty. Please remove all records from it before adding to index");
+
+        if (requireEmpty) {
+          // INDEX SINGLE COLLECTION
+          var collectionId = session.getCollectionIdByName(collectionName);
+          if (session.countCollectionElements(collectionId) > 0) {
+            throw new IndexException("Collection " + collectionName
+                + " is not empty. Please remove all records from it before adding to index");
+          }
         }
 
         save(transaction);

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/IndexManagerEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/IndexManagerEmbedded.java
@@ -90,8 +90,12 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
         });
   }
 
-  public void addCollectionToIndex(DatabaseSessionInternal session, final String collectionName,
-      final String indexName) {
+  public void addCollectionToIndex(
+      DatabaseSessionInternal session,
+      final String collectionName,
+      final String indexName,
+      boolean requireEmpty
+  ) {
     acquireSharedLock();
     try {
       final var index = indexes.get(indexName);
@@ -111,7 +115,7 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
               "Index with name " + indexName + " does not exist.");
         }
         if (!index.getCollections().contains(collectionName)) {
-          index.addCollection(transaction, collectionName);
+          index.addCollection(transaction, collectionName, requireEmpty);
         }
       } finally {
         releaseExclusiveLock(session, true);
@@ -294,7 +298,7 @@ public class IndexManagerEmbedded extends IndexManagerAbstract {
             || indexDefinition.getFields() == null
             || indexDefinition.getFields().isEmpty();
     if (manualIndexesAreUsed) {
-      throw new UnsupportedOperationException("Manual indexes are not supported");
+      throw new UnsupportedOperationException("Manual indexes are not supported: " + iName);
     } else {
       checkSecurityConstraintsForIndexCreate(session, indexDefinition);
     }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/IndexRemote.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/index/IndexRemote.java
@@ -151,7 +151,8 @@ public class IndexRemote implements Index {
   }
 
   @Override
-  public Index addCollection(FrontendTransaction transaction, String collectionName) {
+  public Index addCollection(FrontendTransaction transaction, String collectionName,
+      boolean requireEmpty) {
     throw new UnsupportedOperationException();
   }
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/PropertyTypeInternal.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/PropertyTypeInternal.java
@@ -381,7 +381,7 @@ public enum PropertyTypeInternal {
         }
         case String s -> {
           var entityImpl = session.newEmbeddedEntity(linkedClass);
-          JSONSerializerJackson.fromString(session, s, (RecordAbstract) entityImpl);
+          JSONSerializerJackson.INSTANCE.fromString(session, s, (RecordAbstract) entityImpl);
           return entityImpl;
         }
         default -> {

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaEmbedded.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaEmbedded.java
@@ -182,7 +182,7 @@ public class SchemaEmbedded extends SchemaShared {
       classes.put(key, cls);
 
       if (superClasses != null && !superClasses.isEmpty()) {
-        cls.setSuperClassesInternal(session, superClasses);
+        cls.setSuperClassesInternal(session, superClasses, true);
         for (var superClass : superClasses) {
           // UPDATE INDEXES
           final var collectionsToIndex = superClass.getPolymorphicCollectionIds(session);
@@ -197,7 +197,7 @@ public class SchemaEmbedded extends SchemaShared {
                 session
                     .getSharedContext()
                     .getIndexManager()
-                    .addCollectionToIndex(session, collectionName, index.getName());
+                    .addCollectionToIndex(session, collectionName, index.getName(), true);
               }
             }
           }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaShared.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/metadata/schema/SchemaShared.java
@@ -585,7 +585,7 @@ public abstract class SchemaShared implements CloseableInStorage {
             }
             superClasses.add(superClass);
           }
-          cls.setSuperClassesInternal(session, superClasses);
+          cls.setSuperClassesInternal(session, superClasses, false);
         }
       }
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/RecordAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/record/RecordAbstract.java
@@ -222,7 +222,7 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
 
 
   public <RET extends DBRecord> RET updateFromJSON(final String iSource, final String iOptions) {
-    JSONSerializerJackson.fromString(getSession(),
+    JSONSerializerJackson.INSTANCE.fromString(getSession(),
         iSource, this);
     // nothing change
     return (RET) this;
@@ -230,19 +230,19 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
 
   @Override
   public void updateFromJSON(final @Nonnull String iSource) {
-    JSONSerializerJackson.fromString(getSession(), iSource, this);
+    JSONSerializerJackson.INSTANCE.fromString(getSession(), iSource, this);
   }
 
   // Add New API to load record if rid exist
   public final <RET extends DBRecord> RET updateFromJSON(final String iSource, boolean needReload) {
-    return (RET) JSONSerializerJackson.fromString(getSession(), iSource, this);
+    return (RET) JSONSerializerJackson.INSTANCE.fromString(getSession(), iSource, this);
   }
 
   public final <RET extends DBRecord> RET updateFromJSON(final InputStream iContentResult)
       throws IOException {
     final var out = new ByteArrayOutputStream();
     IOUtils.copyStream(iContentResult, out);
-    JSONSerializerJackson.fromString(getSession(), out.toString(), this);
+    JSONSerializerJackson.INSTANCE.fromString(getSession(), out.toString(), this);
     return (RET) this;
   }
 
@@ -257,9 +257,8 @@ public abstract class RecordAbstract implements DBRecord, RecordElement, Seriali
   public String toJSON(final @Nonnull String format) {
     checkForBinding();
 
-    return JSONSerializerJackson
-        .toString(getSession(), this, new StringWriter(1024),
-            format)
+    return JSONSerializerJackson.INSTANCE
+        .toString(getSession(), this, new StringWriter(1024), format)
         .toString();
   }
 

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/security/DefaultSecuritySystem.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/security/DefaultSecuritySystem.java
@@ -891,7 +891,7 @@ public class DefaultSecuritySystem implements SecuritySystem {
         }
 
         var f = new File(configFile);
-        IOUtils.writeFile(f, JSONSerializerJackson.mapToJson(configEntity));
+        IOUtils.writeFile(f, JSONSerializerJackson.INSTANCE.mapToJson(configEntity));
       }
     } catch (Exception ex) {
       configEntity.put(section, oldSection);
@@ -916,7 +916,7 @@ public class DefaultSecuritySystem implements SecuritySystem {
             final var buffer = new byte[(int) file.length()];
             fis.read(buffer);
 
-            securityEntity = JSONSerializerJackson.mapFromJson(new String(buffer));
+            securityEntity = JSONSerializerJackson.INSTANCE.mapFromJson(new String(buffer));
           }
         } else {
           if (file.exists()) {

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/security/symmetrickey/SymmetricKey.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/security/symmetrickey/SymmetricKey.java
@@ -584,7 +584,7 @@ public class SymmetricKey {
       var json = new String(decoded, StandardCharsets.UTF_8);
 
       // Convert the JSON content to an Map to make parsing it easier.
-      final var map = JSONSerializerJackson.mapFromJson(json);
+      final var map = JSONSerializerJackson.INSTANCE.mapFromJson(json);
 
       // Set a default in case the JSON document does not contain an "algorithm" property.
       var algorithm = secretKeyAlgorithm;

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/security/symmetrickey/SymmetricKeyCI.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/security/symmetrickey/SymmetricKeyCI.java
@@ -74,7 +74,7 @@ public class SymmetricKeyCI implements CredentialInterceptor {
     Map<String, Object> metadata = null;
 
     try {
-      metadata = JSONSerializerJackson.mapFromJson(password);
+      metadata = JSONSerializerJackson.INSTANCE.mapFromJson(password);
     } catch (Exception ex) {
       throw BaseException.wrapException(
           new SecurityException((String) null,

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/serialization/serializer/record/string/JSONSerializerJackson.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/serialization/serializer/record/string/JSONSerializerJackson.java
@@ -24,15 +24,18 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.core.json.JsonReadFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.type.MapType;
 import com.jetbrains.youtrack.db.api.exception.BaseException;
 import com.jetbrains.youtrack.db.api.record.Blob;
 import com.jetbrains.youtrack.db.api.record.DBRecord;
+import com.jetbrains.youtrack.db.api.record.Edge;
 import com.jetbrains.youtrack.db.api.record.EmbeddedEntity;
 import com.jetbrains.youtrack.db.api.record.Entity;
 import com.jetbrains.youtrack.db.api.record.Identifiable;
 import com.jetbrains.youtrack.db.api.record.RID;
+import com.jetbrains.youtrack.db.api.record.Vertex;
 import com.jetbrains.youtrack.db.api.schema.SchemaClass;
 import com.jetbrains.youtrack.db.api.schema.SchemaProperty;
 import com.jetbrains.youtrack.db.internal.common.log.LogManager;
@@ -62,39 +65,79 @@ import java.io.InputStream;
 import java.io.StringWriter;
 import java.io.UnsupportedEncodingException;
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
 
 public class JSONSerializerJackson {
 
-  private static final JsonFactory JSON_FACTORY = new JsonFactory();
+  private final JsonFactory jsonFactory;
 
-  public static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  public static final MapType MAP_TYPE_REFERENCE =
-      OBJECT_MAPPER.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private final MapType mapTypeReference =
+      objectMapper.getTypeFactory().constructMapType(HashMap.class, String.class, Object.class);
 
+  /**
+   * Default JSON serializer.
+   */
+  public static final JSONSerializerJackson INSTANCE =
+      new JSONSerializerJackson(false, false, false, Set.of());
 
-  public static final String NAME = "jackson";
-  public static final JSONSerializerJackson INSTANCE = new JSONSerializerJackson();
+  /**
+   * JSON serializer that is used by DatabaseImport tool. It allows creating graph structures
+   * (vertex and edge records and their in/out properties).
+   */
+  public static final JSONSerializerJackson IMPORT_INSTANCE =
+      new JSONSerializerJackson(false, false, true, Set.of());
 
-  public static Map<String, Object> mapFromJson(@Nonnull String value) {
+  /**
+   * JSON serializer with a set of relaxed rules that is used by DatabaseImport tool in backward
+   * compatibility mode.
+   */
+  public static final JSONSerializerJackson IMPORT_BACKWARDS_COMPAT_INSTANCE =
+      new JSONSerializerJackson(true, true, true, Set.of('$'));
+
+  private final boolean readOldFieldTypesFormat;
+  private final Set<Character> readPrefixUnderscoreReplacements;
+  private final boolean readAllowGraphStructure; // allowing to import Vertex and Edge classes and create edges.
+
+  private JSONSerializerJackson(
+      boolean readUnescapedControlChars,
+      boolean readOldFieldTypesFormat,
+      boolean readAllowGraphStructure,
+      Set<Character> readPrefixUnderscoreReplacements
+  ) {
+    this.readOldFieldTypesFormat = readOldFieldTypesFormat;
+    this.readPrefixUnderscoreReplacements = readPrefixUnderscoreReplacements;
+    this.readAllowGraphStructure = readAllowGraphStructure;
+    final var b = JsonFactory.builder();
+    if (readUnescapedControlChars) {
+      b.enable(JsonReadFeature.ALLOW_UNESCAPED_CONTROL_CHARS);
+    }
+
+    jsonFactory = b.build();
+  }
+
+  public Map<String, Object> mapFromJson(@Nonnull String value) {
     try {
-      return OBJECT_MAPPER.readValue(value, MAP_TYPE_REFERENCE);
+      return objectMapper.readValue(value, mapTypeReference);
     } catch (JsonProcessingException e) {
       throw BaseException.wrapException(
           new SerializationException("Error on unmarshalling JSON content"), e, (String) null);
     }
   }
 
-  public static Map<String, Object> mapFromJson(@Nonnull InputStream stream) throws IOException {
+  public Map<String, Object> mapFromJson(@Nonnull InputStream stream) throws IOException {
     try {
-      return OBJECT_MAPPER.readValue(stream, MAP_TYPE_REFERENCE);
+      return objectMapper.readValue(stream, mapTypeReference);
     } catch (JsonProcessingException e) {
       throw BaseException.wrapException(
           new SerializationException("Error on unmarshalling JSON content"), e, (String) null);
@@ -102,23 +145,23 @@ public class JSONSerializerJackson {
   }
 
   @Nonnull
-  public static String mapToJson(@Nonnull Map<String, ?> value) {
+  public String mapToJson(@Nonnull Map<String, ?> value) {
     try {
-      return OBJECT_MAPPER.writeValueAsString(value);
+      return objectMapper.writeValueAsString(value);
     } catch (JsonProcessingException e) {
       throw BaseException.wrapException(
           new SerializationException("Error on marshalling JSON content"), e, (String) null);
     }
   }
 
-  public static RecordAbstract fromString(
+  public RecordAbstract fromString(
       @Nonnull DatabaseSessionInternal session,
       @Nonnull String source
   ) {
     return fromStringWithMetadata(session, source, null, false).first();
   }
 
-  public static RecordAbstract fromString(
+  public RecordAbstract fromString(
       @Nonnull DatabaseSessionInternal session,
       @Nonnull String source,
       @Nullable RecordAbstract record
@@ -127,13 +170,13 @@ public class JSONSerializerJackson {
   }
 
   @Nonnull
-  public static RawPair<RecordAbstract, RecordMetadata> fromStringWithMetadata(
+  public RawPair<RecordAbstract, RecordMetadata> fromStringWithMetadata(
       @Nonnull DatabaseSessionInternal session,
       @Nonnull String source,
       @Nullable RecordAbstract record,
       boolean ignoreRid
   ) {
-    try (var jsonParser = JSON_FACTORY.createParser(source)) {
+    try (var jsonParser = jsonFactory.createParser(source)) {
       return recordFromJson(session, record, jsonParser, ignoreRid);
     } catch (Exception e) {
       if (record != null && record.getIdentity().isValidPosition()) {
@@ -151,7 +194,7 @@ public class JSONSerializerJackson {
   }
 
   @Nonnull
-  private static RawPair<RecordAbstract, RecordMetadata> recordFromJson(
+  private RawPair<RecordAbstract, RecordMetadata> recordFromJson(
       @Nonnull DatabaseSessionInternal session,
       @Nullable RecordAbstract record,
       @Nonnull JsonParser jsonParser,
@@ -199,7 +242,7 @@ public class JSONSerializerJackson {
     return new RawPair<>(result, recordMetaData);
   }
 
-  private static RecordAbstract createRecordFromJsonAfterMetadata(
+  private RecordAbstract createRecordFromJsonAfterMetadata(
       DatabaseSessionInternal session,
       RecordAbstract record,
       RecordMetadata recordMetaData,
@@ -233,7 +276,11 @@ public class JSONSerializerJackson {
             if (schemaClass.isVertexType()) {
               record = (RecordAbstract) session.newVertex(schemaClass);
             } else if (schemaClass.isEdgeType()) {
-              throw new UnsupportedEncodingException("Edges can not be created from JSON");
+              if (readAllowGraphStructure) {
+                record = session.newStatefulEdgeInternal(schemaClass.getName());
+              } else {
+                throw new UnsupportedEncodingException("Edges can not be created from JSON");
+              }
             } else {
               record = (RecordAbstract) session.newEntity(schemaClass);
             }
@@ -245,8 +292,6 @@ public class JSONSerializerJackson {
               "Unsupported record type: " + recordMetaData.recordType);
         }
       }
-
-      final var rec = record;
     } else {
       if (record.getRecordType() != recordMetaData.recordType) {
         throw new SerializationException(session,
@@ -264,7 +309,7 @@ public class JSONSerializerJackson {
         if (!Objects.equals(className, recordMetaData.className)) {
           if (recordMetaData.className == null) {
             throw new SerializationException(session,
-                "Record class name mismatch: " + className + " != " + recordMetaData.className);
+                "Record class name mismatch: " + className + " != " + null);
           }
 
           var schemaSnapshot = session.getMetadata().getImmutableSchemaSnapshot();
@@ -300,29 +345,33 @@ public class JSONSerializerJackson {
     return record;
   }
 
-  private static void parseProperties(DatabaseSessionInternal session, RecordAbstract record,
+  private void parseProperties(DatabaseSessionInternal session, RecordAbstract record,
       RecordMetadata recordMetaData, JsonParser jsonParser) throws IOException {
     JsonToken token;
     token = jsonParser.currentToken();
 
     while (token != JsonToken.END_OBJECT) {
-      if (token == JsonToken.FIELD_NAME) {
-        var fieldName = jsonParser.currentName();
-        if (!fieldName.isEmpty() && fieldName.charAt(0) == '@') {
-          throw new SerializationException(session, "Invalid property name: " + fieldName);
-        }
-
-        jsonParser.nextToken();//jump to value
-        parseProperty(session, recordMetaData.fieldTypes, record, jsonParser, fieldName);
-      } else {
+      if (token != JsonToken.FIELD_NAME) {
         throw new SerializationException(session, "Expected field name");
       }
+      var fieldName = jsonParser.currentName();
+      jsonParser.nextToken();//jump to value
+
+      if (readOldFieldTypesFormat && "@fieldTypes".equals(fieldName)) {
+        // ignore the value
+        parseValue(session, null, jsonParser, PropertyTypeInternal.STRING, null);
+      } else if (!fieldName.isEmpty() && fieldName.charAt(0) == '@') {
+          throw new SerializationException(session, "Invalid property name: " + fieldName);
+      } else {
+        parseProperty(session, recordMetaData.fieldTypes, record, jsonParser, fieldName);
+      }
+
       token = jsonParser.nextToken();
     }
   }
 
   @Nullable
-  private static RecordMetadata parseRecordMetadata(
+  private RecordMetadata parseRecordMetadata(
       @Nonnull DatabaseSessionInternal session,
       @Nullable JsonParser jsonParser,
       @Nullable String defaultClassName,
@@ -523,33 +572,48 @@ public class JSONSerializerJackson {
     );
   }
 
-  private static Map<String, String> parseFieldTypes(JsonParser jsonParser) throws IOException {
+  private Map<String, String> parseFieldTypes(JsonParser jsonParser) throws IOException {
     var map = new HashMap<String, String>();
 
     var token = jsonParser.nextToken();
-    if (token != JsonToken.START_OBJECT) {
-      throw new SerializationException("Expected start of object");
-    }
+    if (token == JsonToken.START_OBJECT) {
 
-    while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
-      var fieldName = jsonParser.currentName();
-      token = jsonParser.nextToken();
-      if (token != JsonToken.VALUE_STRING) {
-        throw new SerializationException("Expected field value as string");
+      while (jsonParser.nextToken() != JsonToken.END_OBJECT) {
+        var fieldName = jsonParser.currentName();
+        token = jsonParser.nextToken();
+        if (token != JsonToken.VALUE_STRING) {
+          throw new SerializationException("Expected field value as string");
+        }
+
+        map.put(fieldName, jsonParser.getText());
       }
+    } else if (readOldFieldTypesFormat && token == JsonToken.VALUE_STRING) {
+      // old format
 
-      map.put(fieldName, jsonParser.getText());
+      Arrays
+          .stream(StringUtils.split(jsonParser.getText(), ','))
+          .map(ft -> StringUtils.split(ft, '='))
+          .filter(ft -> ft != null && ft.length == 2)
+          .forEach(ft -> map.put(ft[0], ft[1]));
+
+    } else {
+      throw new SerializationException("Bad @fieldTypes format");
     }
 
     return map;
   }
 
-  private static void parseProperty(
+  private void parseProperty(
       DatabaseSessionInternal session,
       Map<String, String> fieldTypes,
       RecordAbstract record,
       JsonParser jsonParser,
       String fieldName) throws IOException {
+
+    if (!fieldName.isEmpty() && readPrefixUnderscoreReplacements.contains(fieldName.charAt(0))) {
+      fieldName = '_' + fieldName.substring(1);
+    }
+
     // RECORD ATTRIBUTES
     if (!(record instanceof EntityImpl entity)) {
       if (fieldName.equals("value")) {
@@ -561,7 +625,11 @@ public class JSONSerializerJackson {
           } else if (record instanceof Blob) {
             // BYTES
             final var iBuffer = jsonParser.getBinaryValue();
-            record.fill(record.getIdentity(), record.getVersion(), iBuffer, true);
+            if (iBuffer != null && iBuffer.length > 0) {
+              record.unsetDirty();
+              record.fromStream(iBuffer);
+              record.setDirty();
+            }
           } else {
             throw new SerializationException(session,
                 "Unsupported type of record : " + record.getClass().getName());
@@ -582,21 +650,40 @@ public class JSONSerializerJackson {
         throw new SerializationException(
             "System property can not be updated from JSON: " + fieldName);
       }
+
       var type =
           determineType(entity, fieldName, fieldTypes.get(fieldName), schemaProperty);
 
-      entity.setPropertyInternal(
-          fieldName,
-          parseValue(session, entity, jsonParser, type, schemaProperty),
-          type, null, true);
+      final var isVertex = entity.isVertex();
+      final var isEdge = entity.isEdge();
+
+      final var isGraphField = readAllowGraphStructure && (
+          isVertex && (
+              fieldName.startsWith(Vertex.DIRECTION_IN_PREFIX) ||
+                  fieldName.startsWith(Vertex.DIRECTION_OUT_PREFIX)
+          ) ||
+              isEdge && (
+                  fieldName.equals(Edge.DIRECTION_IN) ||
+                      fieldName.equals(Edge.DIRECTION_OUT)
+              )
+      );
+
+      final var value = parseValue(session, entity, jsonParser, type, schemaProperty);
+
+      if (isGraphField && isVertex && type == null) {
+        type = PropertyTypeInternal.LINKBAG;
+      }
+
+      // skipping validation when importing graph fields
+      entity.setPropertyInternal(fieldName, value, type, null, !isGraphField);
     }
   }
 
-  public static StringWriter toString(
+  public StringWriter toString(
       DatabaseSessionInternal session, final DBRecord record,
       final StringWriter output,
       final String format) {
-    try (var jsonGenerator = JSON_FACTORY.createGenerator(output)) {
+    try (var jsonGenerator = jsonFactory.createGenerator(output)) {
       final var settings = new FormatSettings(format);
       recordToJson(session, record, jsonGenerator, settings);
       return output;
@@ -607,7 +694,7 @@ public class JSONSerializerJackson {
     }
   }
 
-  public static void recordToJson(DatabaseSessionInternal session, DBRecord record,
+  public void recordToJson(DatabaseSessionInternal session, DBRecord record,
       JsonGenerator jsonGenerator,
       @Nullable String format) {
     try {
@@ -620,7 +707,7 @@ public class JSONSerializerJackson {
     }
   }
 
-  private static void recordToJson(DatabaseSessionInternal session, DBRecord record,
+  private void recordToJson(DatabaseSessionInternal session, DBRecord record,
       JsonGenerator jsonGenerator,
       FormatSettings formatSettings) throws IOException {
     jsonGenerator.writeStartObject();
@@ -710,7 +797,7 @@ public class JSONSerializerJackson {
       if (formatSettings.keepTypes) {
         var fieldTypes = new HashMap<String, String>();
         for (var propertyName : entity.getPropertyNames()) {
-          var type = fetchPropertyType(session, entity,
+          var type = fetchPropertyType(entity,
               propertyName, schemaClass);
 
           if (type != null) {
@@ -743,10 +830,11 @@ public class JSONSerializerJackson {
     }
   }
 
-  private static PropertyTypeInternal fetchPropertyType(DatabaseSessionInternal session,
+  private static PropertyTypeInternal fetchPropertyType(
       EntityImpl entity,
       String propertyName,
-      SchemaClass schemaClass) {
+      SchemaClass schemaClass
+  ) {
     PropertyTypeInternal type = null;
     if (schemaClass != null) {
       var property = schemaClass.getProperty(propertyName);
@@ -792,7 +880,7 @@ public class JSONSerializerJackson {
 
   @Override
   public String toString() {
-    return NAME;
+    return "jackson";
   }
 
   @Nullable
@@ -836,10 +924,10 @@ public class JSONSerializerJackson {
       return type;
     }
 
-    return PropertyTypeInternal.convertFromPublicType(entity.getPropertyType(fieldName));
+    return entity.getPropertyTypeInternal(fieldName);
   }
 
-  private static void serializeValue(DatabaseSessionInternal session, JsonGenerator jsonGenerator,
+  private void serializeValue(DatabaseSessionInternal session, JsonGenerator jsonGenerator,
       Object propertyValue,
       FormatSettings formatSettings)
       throws IOException {
@@ -924,7 +1012,7 @@ public class JSONSerializerJackson {
     }
   }
 
-  public static void serializeEmbeddedMap(DatabaseSessionInternal session,
+  public void serializeEmbeddedMap(DatabaseSessionInternal session,
       JsonGenerator jsonGenerator,
       Map<String, ?> trackedMap, String format) {
     try {
@@ -937,7 +1025,7 @@ public class JSONSerializerJackson {
     }
   }
 
-  private static void serializeEmbeddedMap(DatabaseSessionInternal db, JsonGenerator jsonGenerator,
+  private void serializeEmbeddedMap(DatabaseSessionInternal db, JsonGenerator jsonGenerator,
       FormatSettings formatSettings,
       Map<String, ?> trackedMap) throws IOException {
     jsonGenerator.writeStartObject();
@@ -949,7 +1037,7 @@ public class JSONSerializerJackson {
   }
 
   @Nullable
-  private static Object parseValue(
+  private Object parseValue(
       @Nonnull DatabaseSessionInternal session,
       @Nullable final EntityImpl entity,
       @Nonnull JsonParser jsonParser,
@@ -1027,7 +1115,7 @@ public class JSONSerializerJackson {
     };
   }
 
-  private static RecordElement parseAnyList(@Nonnull DatabaseSessionInternal session,
+  private RecordElement parseAnyList(@Nonnull DatabaseSessionInternal session,
       @Nullable EntityImpl entity, @Nonnull JsonParser jsonParser,
       @Nullable SchemaProperty schemaProperty) throws IOException {
 
@@ -1048,7 +1136,7 @@ public class JSONSerializerJackson {
     }
   }
 
-  private static RecordElement parseObjectOrMap(@Nonnull DatabaseSessionInternal session,
+  private RecordElement parseObjectOrMap(@Nonnull DatabaseSessionInternal session,
       @Nullable EntityImpl entity, @Nonnull JsonParser jsonParser,
       @Nullable SchemaProperty schemaProperty) throws IOException {
     var recordMetaData =
@@ -1103,7 +1191,7 @@ public class JSONSerializerJackson {
   }
 
   @Nonnull
-  private static EmbeddedEntityImpl parseEmbeddedEntity(@Nonnull DatabaseSessionInternal db,
+  private EmbeddedEntityImpl parseEmbeddedEntity(@Nonnull DatabaseSessionInternal db,
       @Nonnull JsonParser jsonParser, @Nullable RecordMetadata metadata,
       SchemaProperty schemaProperty) throws IOException {
 
@@ -1136,7 +1224,7 @@ public class JSONSerializerJackson {
     return embedded;
   }
 
-  private static EntityEmbeddedMapImpl<Object> parseEmbeddedMap(
+  private EntityEmbeddedMapImpl<Object> parseEmbeddedMap(
       @Nonnull DatabaseSessionInternal session,
       @Nullable EntityImpl entity,
       @Nonnull JsonParser jsonParser,
@@ -1202,7 +1290,7 @@ public class JSONSerializerJackson {
     return bag;
   }
 
-  private static EntityEmbeddedListImpl<Object> parseEmbeddedList(
+  private EntityEmbeddedListImpl<Object> parseEmbeddedList(
       DatabaseSessionInternal session,
       EntityImpl entity,
       JsonParser jsonParser,
@@ -1224,7 +1312,7 @@ public class JSONSerializerJackson {
     return list;
   }
 
-  private static EntityEmbeddedSetImpl<Object> parseEmbeddedSet(DatabaseSessionInternal session,
+  private EntityEmbeddedSetImpl<Object> parseEmbeddedSet(DatabaseSessionInternal session,
       EntityImpl entity,
       JsonParser jsonParser, SchemaProperty schemaProperty) throws IOException {
     var list = new EntityEmbeddedSetImpl<>(entity);

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/SQLHelper.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/SQLHelper.java
@@ -187,7 +187,7 @@ public class SQLHelper {
         } else {
           entity = session.newEntity(schemaClass);
         }
-        fieldValue = JSONSerializerJackson.fromString(session, iValue, (RecordAbstract) entity);
+        fieldValue = JSONSerializerJackson.INSTANCE.fromString(session, iValue, (RecordAbstract) entity);
       } else {
         final var items =
             StringSerializerHelper.smartSplit(
@@ -264,7 +264,7 @@ public class SQLHelper {
             entity = session.newEntity();
           }
 
-          fieldValue = JSONSerializerJackson.fromString(session, iValue, (RecordAbstract) entity);
+          fieldValue = JSONSerializerJackson.INSTANCE.fromString(session, iValue, (RecordAbstract) entity);
         } else {
           fieldValue = map;
         }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/text/SQLMethodToJSON.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/sql/functions/text/SQLMethodToJSON.java
@@ -64,7 +64,7 @@ public class SQLMethodToJSON extends AbstractSQLMethod {
     } else if (current instanceof Map) {
 
       //noinspection unchecked
-      return JSONSerializerJackson.mapToJson((Map<String, Object>) current);
+      return JSONSerializerJackson.INSTANCE.mapToJson((Map<String, Object>) current);
     } else if (MultiValue.isMultiValue(current)) {
       var builder = new StringBuilder();
       builder.append("[");

--- a/lucene/src/main/java/com/jetbrains/youtrack/db/internal/lucene/engine/LuceneIndexEngineAbstract.java
+++ b/lucene/src/main/java/com/jetbrains/youtrack/db/internal/lucene/engine/LuceneIndexEngineAbstract.java
@@ -263,7 +263,7 @@ public abstract class LuceneIndexEngineAbstract implements LuceneIndexEngine {
           searcher.search(new TermQuery(new Term("_CLASS", "JSON_METADATA")), 1);
       var jsonFactory = new JsonFactory();
       if (topDocs.totalHits == 0) {
-        var metaAsJson = JSONSerializerJackson.mapToJson(metadata);
+        var metaAsJson = JSONSerializerJackson.INSTANCE.mapToJson(metadata);
 
         String defAsJson;
         var jsonWriter = new StringWriter();

--- a/lucene/src/main/java/com/jetbrains/youtrack/db/internal/lucene/functions/LuceneSearchFunctionTemplate.java
+++ b/lucene/src/main/java/com/jetbrains/youtrack/db/internal/lucene/functions/LuceneSearchFunctionTemplate.java
@@ -81,9 +81,9 @@ public abstract class LuceneSearchFunctionTemplate extends SQLFunctionAbstract
     } else if (md instanceof Map map) {
       return map;
     } else if (md instanceof String) {
-      return JSONSerializerJackson.mapFromJson((String) md);
+      return JSONSerializerJackson.INSTANCE.mapFromJson((String) md);
     } else {
-      return JSONSerializerJackson.mapFromJson(metadata.toString());
+      return JSONSerializerJackson.INSTANCE.mapFromJson(metadata.toString());
     }
   }
 

--- a/lucene/src/main/java/com/jetbrains/youtrack/db/internal/lucene/functions/LuceneSearchMoreLikeThisFunction.java
+++ b/lucene/src/main/java/com/jetbrains/youtrack/db/internal/lucene/functions/LuceneSearchMoreLikeThisFunction.java
@@ -178,7 +178,7 @@ public class LuceneSearchMoreLikeThisFunction extends SQLFunctionAbstract
   }
 
   private static Map<String, ?> parseMetadata(SQLExpression[] args) {
-    return JSONSerializerJackson.mapFromJson(args[1].toString());
+    return JSONSerializerJackson.INSTANCE.mapFromJson(args[1].toString());
   }
 
   private MoreLikeThis buildMoreLikeThis(

--- a/lucene/src/main/java/com/jetbrains/youtrack/db/internal/spatial/functions/SpatialFunctionAbstractIndexable.java
+++ b/lucene/src/main/java/com/jetbrains/youtrack/db/internal/spatial/functions/SpatialFunctionAbstractIndexable.java
@@ -95,7 +95,7 @@ public abstract class SpatialFunctionAbstractIndexable extends SpatialFunctionAb
     Object shape;
 
     if (args[1].getValue() instanceof SQLJson json) {
-      shape = JSONSerializerJackson.mapFromJson(json.toString());
+      shape = JSONSerializerJackson.INSTANCE.mapFromJson(json.toString());
     } else {
       shape = args[1].execute((Identifiable) null, ctx);
     }

--- a/lucene/src/test/java/com/jetbrains/youtrack/db/internal/lucene/analyzer/LuceneAnalyzerFactoryTest.java
+++ b/lucene/src/test/java/com/jetbrains/youtrack/db/internal/lucene/analyzer/LuceneAnalyzerFactoryTest.java
@@ -39,7 +39,7 @@ public class LuceneAnalyzerFactoryTest extends LuceneBaseTest {
 
     var metajson =
         IOUtils.readFileAsString(new File("./src/test/resources/index_metadata_new.json"));
-    metadata = JSONSerializerJackson.mapFromJson(metajson);
+    metadata = JSONSerializerJackson.INSTANCE.mapFromJson(metajson);
 
     indexDef = Mockito.mock(IndexDefinition.class);
     when(indexDef.getFields())

--- a/lucene/src/test/java/com/jetbrains/youtrack/db/internal/lucene/engine/LuceneIndexWriterFactoryTest.java
+++ b/lucene/src/test/java/com/jetbrains/youtrack/db/internal/lucene/engine/LuceneIndexWriterFactoryTest.java
@@ -21,7 +21,7 @@ public class LuceneIndexWriterFactoryTest extends BaseLuceneTest {
     var fc = new LuceneIndexWriterFactory();
 
     // sample metadata json
-    var meta = JSONSerializerJackson.mapFromJson(IOUtils.readFileAsString(
+    var meta = JSONSerializerJackson.INSTANCE.mapFromJson(IOUtils.readFileAsString(
         new File("./src/test/resources/index_metadata_new.json")));
     var writer = fc.createIndexWriter(new RAMDirectory(), meta,
         new StandardAnalyzer());

--- a/lucene/src/test/java/com/jetbrains/youtrack/db/internal/lucene/test/LuceneAutomaticBackupRestoreTest.java
+++ b/lucene/src/test/java/com/jetbrains/youtrack/db/internal/lucene/test/LuceneAutomaticBackupRestoreTest.java
@@ -154,7 +154,7 @@ public class LuceneAutomaticBackupRestoreTest {
         IOUtils.readStreamAsString(
             getClass().getClassLoader().getResourceAsStream("automatic-backup.json"));
 
-    var map = JSONSerializerJackson.mapFromJson(jsonConfig);
+    var map = JSONSerializerJackson.INSTANCE.mapFromJson(jsonConfig);
 
     map.put("enabled", true);
     map.put("targetFileName", "${DBNAME}.json");
@@ -167,7 +167,7 @@ public class LuceneAutomaticBackupRestoreTest {
         new SimpleDateFormat("HH:mm:ss").format(new Date(System.currentTimeMillis() + 2000)));
 
     IOUtils.writeFile(new File(tempFolder, "config/automatic-backup.json"),
-        JSONSerializerJackson.mapToJson(map));
+        JSONSerializerJackson.INSTANCE.mapToJson(map));
 
     final var aBackup = new AutomaticBackup();
     final var latch = new CountDownLatch(1);

--- a/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/BaseSpatialLuceneTest.java
+++ b/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/BaseSpatialLuceneTest.java
@@ -137,7 +137,7 @@ public abstract class BaseSpatialLuceneTest extends BaseLuceneTest {
   protected EmbeddedEntity loadMultiPolygon() throws IOException {
     var systemResourceAsStream = ClassLoader.getSystemResourceAsStream("italy.json");
 
-    var map = JSONSerializerJackson.mapFromJson(systemResourceAsStream);
+    var map = JSONSerializerJackson.INSTANCE.mapFromJson(systemResourceAsStream);
 
     Map geometry = (Map) map.get("geometry");
 

--- a/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/LuceneSpatialAutomaticBackupRestoreTest.java
+++ b/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/LuceneSpatialAutomaticBackupRestoreTest.java
@@ -170,7 +170,7 @@ public class LuceneSpatialAutomaticBackupRestoreTest {
         IOUtils.readStreamAsString(
             getClass().getClassLoader().getResourceAsStream("automatic-backup.json"));
 
-    var map = JSONSerializerJackson.mapFromJson(jsonConfig);
+    var map = JSONSerializerJackson.INSTANCE.mapFromJson(jsonConfig);
     map.put("enabled", true);
     map.put("targetFileName", "${DBNAME}.json");
     map.put("targetDirectory", BACKUPDIR);
@@ -183,7 +183,7 @@ public class LuceneSpatialAutomaticBackupRestoreTest {
 
     IOUtils.writeFile(
         new File(tempFolder.getAbsolutePath() + "/config/automatic-backup.json"),
-        JSONSerializerJackson.mapToJson(map));
+        JSONSerializerJackson.INSTANCE.mapToJson(map));
 
     final var aBackup = new AutomaticBackup();
 

--- a/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/LuceneSpatialPolygonTest.java
+++ b/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/LuceneSpatialPolygonTest.java
@@ -67,7 +67,7 @@ public class LuceneSpatialPolygonTest extends BaseSpatialLuceneTest {
     session.begin();
     var systemResourceAsStream = ClassLoader.getSystemResourceAsStream("germany.json");
 
-    var map = JSONSerializerJackson.mapFromJson(systemResourceAsStream);
+    var map = JSONSerializerJackson.INSTANCE.mapFromJson(systemResourceAsStream);
 
     Map geometry = (Map) map.get("geometry");
 

--- a/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/sandbox/LuceneGeoTest.java
+++ b/lucene/src/test/java/com/jetbrains/youtrack/db/internal/spatial/sandbox/LuceneGeoTest.java
@@ -195,7 +195,7 @@ public class LuceneGeoTest extends BaseLuceneTest {
       throws IOException {
     var systemResourceAsStream = ClassLoader.getSystemResourceAsStream("italy.json");
 
-    var map = JSONSerializerJackson.mapFromJson(systemResourceAsStream);
+    var map = JSONSerializerJackson.INSTANCE.mapFromJson(systemResourceAsStream);
 
     Map geometry = (Map) map.get("geometry");
     var type = (String) geometry.get("type");

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/handler/AutomaticBackup.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/handler/AutomaticBackup.java
@@ -290,7 +290,7 @@ public class AutomaticBackup extends ServerPluginAbstract implements ServerPlugi
       // READ THE FILE
       try {
         final var configurationContent = IOUtils.readFileAsString(f);
-        configuration = JSONSerializerJackson.mapFromJson(configurationContent);
+        configuration = JSONSerializerJackson.INSTANCE.mapFromJson(configurationContent);
       } catch (IOException e) {
         throw BaseException.wrapException(
             new ConfigurationException((String) null,
@@ -305,7 +305,7 @@ public class AutomaticBackup extends ServerPluginAbstract implements ServerPlugi
       try {
         f.getParentFile().mkdirs();
         f.createNewFile();
-        IOUtils.writeFile(f, JSONSerializerJackson.mapToJson(configuration));
+        IOUtils.writeFile(f, JSONSerializerJackson.INSTANCE.mapToJson(configuration));
 
         LogManager.instance()
             .info(this, "Automatic Backup: migrated configuration to file '%s'", f);

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/NetworkProtocolHttpAbstract.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/NetworkProtocolHttpAbstract.java
@@ -565,7 +565,7 @@ public abstract class NetworkProtocolHttpAbstract extends NetworkProtocol
 
     response.put("errors", errors);
 
-    binaryContent = JSONSerializerJackson.mapToJson(response).getBytes(utf8);
+    binaryContent = JSONSerializerJackson.INSTANCE.mapToJson(response).getBytes(utf8);
 
     writeLine(
         HttpUtils.HEADER_CONTENT_LENGTH + binaryContent.length);

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/ServerCommandAbstract.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/ServerCommandAbstract.java
@@ -108,7 +108,7 @@ public abstract class ServerCommandAbstract implements ServerCommand {
     errors.add(error);
     response.put("errors", errors);
     iResponse.send(
-        iCode, iReason, HttpUtils.CONTENT_JSON, JSONSerializerJackson.mapToJson(response),
+        iCode, iReason, HttpUtils.CONTENT_JSON, JSONSerializerJackson.INSTANCE.mapToJson(response),
         iHeaders);
   }
 }

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/all/ServerCommandAbstractLogic.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/all/ServerCommandAbstractLogic.java
@@ -78,7 +78,7 @@ public abstract class ServerCommandAbstractLogic extends ServerCommandAuthentica
         if (args.length == 0 && iRequest.getContent() != null && !iRequest.getContent().isEmpty()) {
           // PARSE PARAMETERS FROM CONTENT PAYLOAD
           try {
-            final var params = JSONSerializerJackson.mapFromJson(iRequest.getContent());
+            final var params = JSONSerializerJackson.INSTANCE.mapFromJson(iRequest.getContent());
             functionResult = f.executeInContext(context, params);
           } catch (Exception e) {
             throw BaseException.wrapException(

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/get/ServerCommandGetListDatabases.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/get/ServerCommandGetListDatabases.java
@@ -86,7 +86,7 @@ public class ServerCommandGetListDatabases extends ServerCommandAuthenticatedSer
         HttpUtils.STATUS_OK_CODE,
         HttpUtils.STATUS_OK_DESCRIPTION,
         HttpUtils.CONTENT_JSON,
-        JSONSerializerJackson.mapToJson(result),
+        JSONSerializerJackson.INSTANCE.mapToJson(result),
         null);
 
     return false;

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/patch/ServerCommandPatchDocument.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/patch/ServerCommandPatchDocument.java
@@ -63,7 +63,7 @@ public class ServerCommandPatchDocument extends ServerCommandDocumentAbstract {
                 }
 
                 // UNMARSHALL DOCUMENT WITH REQUEST CONTENT
-                var content = JSONSerializerJackson.mapFromJson(iRequest.getContent());
+                var content = JSONSerializerJackson.INSTANCE.mapFromJson(iRequest.getContent());
                 final int recordVersion;
 
                 if (iRequest.getIfMatch() != null)

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostAuthToken.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostAuthToken.java
@@ -142,7 +142,7 @@ public class ServerCommandPostAuthToken extends ServerCommandAbstract {
         HttpUtils.STATUS_BADREQ_CODE,
         HttpUtils.STATUS_BADREQ_DESCRIPTION,
         HttpUtils.CONTENT_JSON,
-        JSONSerializerJackson.mapToJson(error),
+        JSONSerializerJackson.INSTANCE.mapToJson(error),
         null);
   }
 

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostBatch.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostBatch.java
@@ -101,7 +101,7 @@ public class ServerCommandPostBatch extends ServerCommandDocumentAbstract {
         db.rollback(true);
       }
 
-      var batch = JSONSerializerJackson.mapFromJson(iRequest.getContent());
+      var batch = JSONSerializerJackson.INSTANCE.mapFromJson(iRequest.getContent());
 
       var tx = (Boolean) batch.get("transaction");
       if (tx == null) {
@@ -247,7 +247,7 @@ public class ServerCommandPostBatch extends ServerCommandDocumentAbstract {
                 this,
                 "Error (%s) on serializing result of batch command:\n%s",
                 e,
-                JSONSerializerJackson.mapToJson(batch));
+                JSONSerializerJackson.INSTANCE.mapToJson(batch));
         throw e;
       }
 

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostCommand.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostCommand.java
@@ -70,7 +70,7 @@ public class ServerCommandPostCommand extends ServerCommandAuthenticatedDbAbstra
       // CONTENT REPLACES TEXT
       if (iRequest.getContent().startsWith("{")) {
         // JSON PAYLOAD
-        final var map = JSONSerializerJackson.mapFromJson(iRequest.getContent());
+        final var map = JSONSerializerJackson.INSTANCE.mapFromJson(iRequest.getContent());
         text = (String) map.get("command");
         params = map.get("parameters");
         if (map.containsKey("mode")) {

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostDatabase.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostDatabase.java
@@ -70,7 +70,7 @@ public class ServerCommandPostDatabase extends ServerCommandAuthenticatedServerA
       if (iRequest.getContent().startsWith("{")) {
         // JSON PAYLOAD
 
-        var result = JSONSerializerJackson.mapFromJson(iRequest.getContent());
+        var result = JSONSerializerJackson.INSTANCE.mapFromJson(iRequest.getContent());
 
         if (result.containsKey("adminPassword")) {
           createAdmin = true;

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostProperty.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostProperty.java
@@ -141,7 +141,7 @@ public class ServerCommandPostProperty extends ServerCommandAuthenticatedDbAbstr
 
     final var cls = db.getMetadata().getSchema().getClass(urlParts[2]);
 
-    final var properties = JSONSerializerJackson.mapFromJson(iRequest.getContent());
+    final var properties = JSONSerializerJackson.INSTANCE.mapFromJson(iRequest.getContent());
 
     for (var entry : properties.entrySet()) {
       var propertyName = entry.getKey();

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostServerCommand.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/post/ServerCommandPostServerCommand.java
@@ -60,7 +60,7 @@ public class ServerCommandPostServerCommand extends ServerCommandAuthenticatedSe
       // CONTENT REPLACES TEXT
       if (iRequest.getContent().startsWith("{")) {
         // JSON PAYLOAD
-        final var content = JSONSerializerJackson.mapFromJson(iRequest.getContent());
+        final var content = JSONSerializerJackson.INSTANCE.mapFromJson(iRequest.getContent());
         text = (String) content.get("command");
         params = content.get("parameters");
 

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/put/ServerCommandPutDocument.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/network/protocol/http/command/put/ServerCommandPutDocument.java
@@ -66,7 +66,7 @@ public class ServerCommandPutDocument extends ServerCommandDocumentAbstract {
           db.computeInTx(
               tx -> {
                 var txRecordId = recordId;
-                final var content = JSONSerializerJackson.mapFromJson(
+                final var content = JSONSerializerJackson.INSTANCE.mapFromJson(
                     iRequest.getContent());
                 final int recordVersion;
                 // UNMARSHALL DOCUMENT WITH REQUEST CONTENT

--- a/server/src/main/java/com/jetbrains/youtrack/db/internal/server/token/TokenHandlerImpl.java
+++ b/server/src/main/java/com/jetbrains/youtrack/db/internal/server/token/TokenHandlerImpl.java
@@ -389,7 +389,7 @@ public class TokenHandlerImpl implements TokenHandler {
   }
 
   protected static YouTrackDBJwtHeader deserializeWebHeader(final byte[] decodedHeader) {
-    final var map = JSONSerializerJackson.mapFromJson(
+    final var map = JSONSerializerJackson.INSTANCE.mapFromJson(
         new String(decodedHeader, StandardCharsets.UTF_8));
     final var header = new YouTrackDBJwtHeader();
     header.setType((String) map.get("typ"));
@@ -403,7 +403,7 @@ public class TokenHandlerImpl implements TokenHandler {
     if (!"YouTrackDB".equals(type)) {
       throw new SystemException("Payload class not registered:" + type);
     }
-    final var map = JSONSerializerJackson.mapFromJson(
+    final var map = JSONSerializerJackson.INSTANCE.mapFromJson(
         new String(decodedPayload, StandardCharsets.UTF_8));
     final var payload = new YouTrackDBJwtPayload();
     payload.setUserName((String) map.get("username"));
@@ -432,7 +432,7 @@ public class TokenHandlerImpl implements TokenHandler {
     map.put("alg", header.getAlgorithm());
     map.put("kid", header.getKeyId());
 
-    return JSONSerializerJackson.mapToJson(map).getBytes(StandardCharsets.UTF_8);
+    return JSONSerializerJackson.INSTANCE.mapToJson(map).getBytes(StandardCharsets.UTF_8);
   }
 
   protected static byte[] serializeWebPayload(final JwtPayload payload) throws Exception {
@@ -452,7 +452,7 @@ public class TokenHandlerImpl implements TokenHandler {
     map.put("uidc", payload.getUserRid().getCollectionId());
     map.put("uidp", payload.getUserRid().getCollectionPosition());
     map.put("bdtyp", payload.getDatabaseType());
-    return JSONSerializerJackson.mapToJson(map).getBytes(StandardCharsets.UTF_8);
+    return JSONSerializerJackson.INSTANCE.mapToJson(map).getBytes(StandardCharsets.UTF_8);
   }
 
   protected JwtPayload createPayloadServerUser(SecurityUser serverUser) {

--- a/server/src/test/java/com/jetbrains/youtrack/db/internal/server/ServerDatabaseOperationsTest.java
+++ b/server/src/test/java/com/jetbrains/youtrack/db/internal/server/ServerDatabaseOperationsTest.java
@@ -63,7 +63,7 @@ public class ServerDatabaseOperationsTest {
     try (var session = server.openSession(
         ServerDatabaseOperationsTest.class.getSimpleName())) {
 
-      var map = JSONSerializerJackson.mapFromJson(IOUtils.readStreamAsString(
+      var map = JSONSerializerJackson.INSTANCE.mapFromJson(IOUtils.readStreamAsString(
           this.getClass().getClassLoader().getResourceAsStream("security.json")));
       server.getSecurity().reload(session, map);
     } finally {

--- a/server/src/test/java/com/jetbrains/youtrack/db/internal/server/http/BaseHttpDatabaseTest.java
+++ b/server/src/test/java/com/jetbrains/youtrack/db/internal/server/http/BaseHttpDatabaseTest.java
@@ -26,7 +26,7 @@ public abstract class BaseHttpDatabaseTest extends BaseHttpTest {
     Assert.assertEquals(
         200,
         post("database/" + getDatabaseName() + "/memory")
-            .payload(JSONSerializerJackson.mapToJson(pass), CONTENT.JSON)
+            .payload(JSONSerializerJackson.INSTANCE.mapToJson(pass), CONTENT.JSON)
             .setUserName("root")
             .setUserPassword("root")
             .getResponse()

--- a/server/src/test/java/com/jetbrains/youtrack/db/internal/server/http/HttpDatabaseTest.java
+++ b/server/src/test/java/com/jetbrains/youtrack/db/internal/server/http/HttpDatabaseTest.java
@@ -50,7 +50,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
         setUserName("root")
             .setUserPassword("root")
             .post("database/" + getDatabaseName() + "/memory")
-            .payload(JSONSerializerJackson.mapToJson(pass), CONTENT.JSON)
+            .payload(JSONSerializerJackson.INSTANCE.mapToJson(pass), CONTENT.JSON)
             .getResponse()
             .getCode());
 
@@ -78,7 +78,7 @@ public class HttpDatabaseTest extends BaseHttpTest {
         setUserName("root")
             .setUserPassword("root")
             .post("database/" + getDatabaseName() + "/memory")
-            .payload(JSONSerializerJackson.mapToJson(pass), CONTENT.JSON)
+            .payload(JSONSerializerJackson.INSTANCE.mapToJson(pass), CONTENT.JSON)
             .getResponse()
             .getCode());
 

--- a/server/src/test/java/com/jetbrains/youtrack/db/internal/server/http/HttpGraphTest.java
+++ b/server/src/test/java/com/jetbrains/youtrack/db/internal/server/http/HttpGraphTest.java
@@ -113,7 +113,7 @@ public class HttpGraphTest extends BaseHttpDatabaseTest {
     final var payload = new HashMap<String, String>();
     payload.put("command", "select from E");
     payload.put("mode", "graph");
-    var json = JSONSerializerJackson.mapToJson(payload);
+    var json = JSONSerializerJackson.INSTANCE.mapToJson(payload);
 
     response =
         post("command/" + getDatabaseName() + "/sql/").payload(json, CONTENT.JSON).getResponse();


### PR DESCRIPTION
This pull request:
1) adds backward compatibility to DatabaseImport tool;
2) fixes importing graph structures (vertexes and edges);
3) simplifies collections/clusters import and potentially fixes index creation;
4) fixes exporting of links to blob records.

The main changes are in `JSONSerializerJackson` and `DatabaseImport`.

We have a Slack chat for contributors. If you wish to join, please read [this article](https://youtrack.jetbrains.com/articles/YTDB-A-5/Slack-with-developers-for-contributors).
