### PR TITLE
Fixing transaction usage in executeInTxBatches

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionAbstract.java
@@ -2230,26 +2230,7 @@ public abstract class DatabaseSessionAbstract<IM extends IndexManagerAbstract> e
   @Override
   public <T, X extends Exception> void executeInTxBatches(
       Iterable<T> iterable, int batchSize, TxBiConsumer<Transaction, T, X> consumer) throws X {
-    var ok = false;
-    assert assertIfNotActive();
-    var counter = 0;
-
-    var tx = begin();
-    try {
-      for (var t : iterable) {
-        consumer.accept(tx, t);
-        counter++;
-
-        if (counter % batchSize == 0) {
-          commit();
-          begin();
-        }
-      }
-
-      ok = true;
-    } finally {
-      finishTx(ok);
-    }
+    this.executeInTxBatchesInternal(iterable.iterator(), batchSize, consumer::accept);
   }
 
   @Override

--- a/core/src/test/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionInternalTest.java
+++ b/core/src/test/java/com/jetbrains/youtrack/db/internal/core/db/DatabaseSessionInternalTest.java
@@ -1,0 +1,35 @@
+package com.jetbrains.youtrack.db.internal.core.db;
+
+import static org.assertj.core.api.Java6Assertions.assertThat;
+
+import com.jetbrains.youtrack.db.internal.DbTestBase;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Test;
+
+public class DatabaseSessionInternalTest extends DbTestBase {
+
+  @Test
+  public void testBatchTransaction() {
+
+    final var batchSize = 100;
+    final var batchCount = 10;
+    final var indexes = IntStream.range(0, batchSize * batchCount).boxed()
+        .collect(Collectors.toSet());
+
+    session.getSchema().createClass("TestBatchTransaction");
+    session.executeInTxBatches(indexes, batchSize, (tx, i) -> {
+      tx.newEntity("TestBatchTransaction").setProperty("i", i);
+    });
+
+    final var createdIndexes = session.computeInTx(tx ->
+        tx.query("select i from TestBatchTransaction")
+            .stream()
+            .map(r -> r.getInt("i"))
+            .collect(Collectors.toSet())
+    );
+
+    assertThat(createdIndexes).isEqualTo(indexes);
+  }
+
+}


### PR DESCRIPTION
Previous implementation of `DatabaseSession#executeInTxBatches` had an issue - it was trying to use old transaction instance even after beginning a new one. This PR fixes this by calling `executeInTxBatchesInternal`, which already has that moment fixed.

--

We have a Slack chat for contributors. If you wish to join, please read [this article](https://youtrack.jetbrains.com/articles/YTDB-A-5/Slack-with-developers-for-contributors).
