### PR TITLE
ConsoleDatabaseApp full name fixed in console distribution manifest

### DIFF
--- a/console-distribution/pom.xml
+++ b/console-distribution/pom.xml
@@ -21,7 +21,7 @@
   <artifactId>youtrackdb-console-distribution</artifactId>
   <name>YouTrackDB Console Distribution</name>
   <properties>
-    <jar.manifest.mainclass>com.jetbrains.youtrack.db.internal.console.ConsoleDatabaseApp
+    <jar.manifest.mainclass>com.jetbrains.youtrack.db.internal.tools.console.ConsoleDatabaseApp
     </jar.manifest.mainclass>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!--This property is updated automatically and is needed to make build reproducible-->

--- a/server/script/console.bat
+++ b/server/script/console.bat
@@ -44,6 +44,6 @@ set SSL_OPTS="-Dyoutrackdb.client.ssl.enabled=false -Djavax.net.ssl.keyStore=%KE
 
 set YOUTRACKDB_SETTINGS=-Xmx1024m -Djna.nosys=true -Djava.util.logging.config.file="%YOUTRACKDB_HOME%\config\youtrackdb-client-log.properties" -Djava.awt.headless=true
 
-call %JAVA% -client %SSL_OPTS% %YOUTRACKDB_SETTINGS% -Dfile.encoding=utf-8 -Dyoutrackdb.build.number="@BUILD@" -cp "%YOUTRACKDB_HOME%\lib\*;%YOUTRACKDB_HOME%\plugins\*" com.jetbrains.youtrack.db.internal.console.ConsoleDatabaseApp %CMD_LINE_ARGS%
+call %JAVA% -client %SSL_OPTS% %YOUTRACKDB_SETTINGS% -Dfile.encoding=utf-8 -Dyoutrackdb.build.number="@BUILD@" -cp "%YOUTRACKDB_HOME%\lib\*;%YOUTRACKDB_HOME%\plugins\*" com.jetbrains.youtrack.db.internal.tools.console.ConsoleDatabaseApp %CMD_LINE_ARGS%
 
 :end

--- a/server/script/console.sh
+++ b/server/script/console.sh
@@ -48,4 +48,4 @@ exec "$JAVA" -client $JAVA_OPTS $YOUTRACKDB_OPTS_MEMORY $YOUTRACKDB_SETTINGS $SS
     "-Djavax.net.ssl.keyStorePassword=$KEYSTORE_PASS" \
     "-Djavax.net.ssl.trustStore=$TRUSTSTORE" \
     "-Djavax.net.ssl.trustStorePassword=$TRUSTSTORE_PASS" \
-    com.jetbrains.youtrack.db.internal.console.ConsoleDatabaseApp $*
+    com.jetbrains.youtrack.db.internal.tools.console.ConsoleDatabaseApp $*


### PR DESCRIPTION
Fixing the full name of ConsoleDatabaseApp class throughout the codebase

We have a Slack chat for contributors. If you wish to join, please read [this article](https://youtrack.jetbrains.com/articles/YTDB-A-5/Slack-with-developers-for-contributors).
