### PR TITLE
Removing redundant stack trace from FrontendTransactionImpl

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/tx/FrontendTransactionImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/tx/FrontendTransactionImpl.java
@@ -116,7 +116,6 @@ public class FrontendTransactionImpl implements
   protected int txStartCounter;
   protected boolean sentToServer = false;
   private final boolean readOnly;
-  private final StackTraceElement[] creationStack;
 
   private final RecordSerializationContext recordSerializationContext = new RecordSerializationContext();
 
@@ -128,7 +127,6 @@ public class FrontendTransactionImpl implements
     this.session = session;
     this.id = txSerial.incrementAndGet();
     this.readOnly = readOnly;
-    this.creationStack = Thread.currentThread().getStackTrace();
   }
 
   public FrontendTransactionImpl(@Nonnull final DatabaseSessionEmbedded session, long txId,
@@ -136,7 +134,6 @@ public class FrontendTransactionImpl implements
     this.session = session;
     this.id = txId;
     this.readOnly = readOnly;
-    this.creationStack = Thread.currentThread().getStackTrace();
   }
 
 
@@ -144,7 +141,6 @@ public class FrontendTransactionImpl implements
     this.session = session;
     this.id = id;
     readOnly = false;
-    this.creationStack = Thread.currentThread().getStackTrace();
   }
 
   @Override


### PR DESCRIPTION
Removing redundant stack trace from FrontendTransactionImpl