### PR TITLE
Ability to disable system database initialization in server mode

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrack/db/api/config/GlobalConfiguration.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/api/config/GlobalConfiguration.java
@@ -411,6 +411,13 @@ public enum GlobalConfiguration {
       "youtrackdb.db.validation", "Enables or disables validation of records", Boolean.class, true,
       true),
 
+  DB_SYSTEM_DATABASE_ENABLED(
+      "youtrack.db.systemDatabase.enabled",
+      "Enables usage of system database. If disabled, it will turn off the initialization "
+          + "of system database and system users in server mode and will initiate an error on "
+          + "all attempts to access the system database.",
+      Boolean.class, true, true),
+
   // INDEX
   INDEX_EMBEDDED_TO_SBTREEBONSAI_THRESHOLD(
       "youtrackdb.index.embeddedToSbtreeBonsaiThreshold",

--- a/core/src/main/java/com/jetbrains/youtrack/db/api/config/YouTrackDBConfig.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/api/config/YouTrackDBConfig.java
@@ -2,6 +2,7 @@ package com.jetbrains.youtrack.db.api.config;
 
 import com.jetbrains.youtrack.db.api.common.BasicDatabaseSession.ATTRIBUTES;
 import com.jetbrains.youtrack.db.api.SessionListener;
+import com.jetbrains.youtrack.db.internal.core.config.ContextConfiguration;
 import com.jetbrains.youtrack.db.internal.core.db.YouTrackDBConfigBuilderImpl;
 import com.jetbrains.youtrack.db.internal.core.db.YouTrackDBConfigImpl;
 import java.util.Map;
@@ -25,4 +26,7 @@ public interface YouTrackDBConfig {
 
   @Nonnull
   Set<SessionListener> getListeners();
+
+  @Nonnull
+  ContextConfiguration getConfiguration();
 }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/SystemDatabase.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/SystemDatabase.java
@@ -23,6 +23,7 @@ import com.jetbrains.youtrack.db.api.DatabaseSession;
 import com.jetbrains.youtrack.db.api.DatabaseType;
 import com.jetbrains.youtrack.db.api.config.GlobalConfiguration;
 import com.jetbrains.youtrack.db.api.config.YouTrackDBConfig;
+import com.jetbrains.youtrack.db.api.exception.DatabaseException;
 import com.jetbrains.youtrack.db.api.query.ResultSet;
 import com.jetbrains.youtrack.db.api.record.Entity;
 import com.jetbrains.youtrack.db.internal.common.log.LogManager;
@@ -40,10 +41,13 @@ public class SystemDatabase {
   public static final String SERVER_ID_PROPERTY = "serverId";
 
   private final YouTrackDBInternalEmbedded context;
+  private final boolean enabled;
   private String serverId;
 
   public SystemDatabase(final YouTrackDBInternalEmbedded context) {
     this.context = context;
+    this.enabled = context.getConfiguration().getConfiguration()
+        .getValueAsBoolean(GlobalConfiguration.DB_SYSTEM_DATABASE_ENABLED);
   }
 
   /**
@@ -52,6 +56,7 @@ public class SystemDatabase {
    * called and restoring it after the database is closed.
    */
   public DatabaseSessionInternal openSystemDatabaseSession() {
+    checkIfEnabled();
     if (!exists()) {
       init();
     }
@@ -84,6 +89,7 @@ public class SystemDatabase {
   }
 
   public void init() {
+    checkIfEnabled();
     if (!exists()) {
       LogManager.instance()
           .info(this, "Creating the system database '%s' for current server", SYSTEM_DB_NAME);
@@ -141,12 +147,17 @@ public class SystemDatabase {
     }
   }
 
-
   public boolean exists() {
     return context.exists(SYSTEM_DB_NAME, null, null);
   }
 
   public String getServerId() {
     return serverId;
+  }
+
+  private void checkIfEnabled() {
+    if (!enabled) {
+      throw new DatabaseException("System database is disabled");
+    }
   }
 }

--- a/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/YouTrackDBConfigImpl.java
+++ b/core/src/main/java/com/jetbrains/youtrack/db/internal/core/db/YouTrackDBConfigImpl.java
@@ -78,6 +78,8 @@ public class YouTrackDBConfigImpl implements YouTrackDBConfig {
     return listeners;
   }
 
+  @Override
+  @Nonnull
   public ContextConfiguration getConfiguration() {
     return configuration;
   }

--- a/core/src/test/java/com/jetbrains/youtrack/db/internal/core/db/SystemDatabaseDisabledTest.java
+++ b/core/src/test/java/com/jetbrains/youtrack/db/internal/core/db/SystemDatabaseDisabledTest.java
@@ -1,0 +1,39 @@
+package com.jetbrains.youtrack.db.internal.core.db;
+
+
+import static org.junit.Assert.fail;
+
+import com.jetbrains.youtrack.db.api.config.GlobalConfiguration;
+import com.jetbrains.youtrack.db.api.exception.DatabaseException;
+import com.jetbrains.youtrack.db.internal.DbTestBase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class SystemDatabaseDisabledTest extends DbTestBase {
+
+  @BeforeClass
+  public static void beforeClass() {
+    GlobalConfiguration.DB_SYSTEM_DATABASE_ENABLED.setValue(false);
+  }
+
+  @AfterClass
+  public static void afterClass() {
+    GlobalConfiguration.DB_SYSTEM_DATABASE_ENABLED.setValue(true);
+  }
+
+  @Test
+  public void testDisabledSystemDatabase() {
+
+    try {
+      session.getSharedContext().getYouTrackDB().getSystemDatabase().executeWithDB(
+          s -> s.computeInTx(tx -> tx.query("select count(*) from V"))
+      );
+      fail("Should fail with DatabaseException: System database is disabled");
+    } catch (DatabaseException e) {
+      if (!e.getMessage().contains("System database is disabled")) {
+        throw e;
+      }
+    }
+  }
+}


### PR DESCRIPTION
New config parameter `youtrack.db.systemDatabase.enabled` (true by default) that, if set to false,

1) disables system database initialization in server mode;
2) initiates `DatabaseException` on any attempt to connect to system database.