### PR TITLE
Polymorphic queries: handling multiple hasLabel steps

### DIFF
--- a/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraphQueryBuilder.java
+++ b/core/src/main/java/com/jetbrains/youtrackdb/internal/core/gremlin/YTDBGraphQueryBuilder.java
@@ -2,13 +2,18 @@ package com.jetbrains.youtrackdb.internal.core.gremlin;
 
 import com.jetbrains.youtrackdb.api.schema.SchemaClass;
 import com.jetbrains.youtrackdb.internal.core.db.DatabaseSessionEmbedded;
+import com.jetbrains.youtrackdb.internal.core.metadata.schema.ImmutableSchema;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.commons.lang.StringUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.Compare;
 import org.apache.tinkerpop.gremlin.process.traversal.Contains;
 import org.apache.tinkerpop.gremlin.process.traversal.step.util.HasContainer;
@@ -17,7 +22,17 @@ import org.apache.tinkerpop.gremlin.structure.T;
 public class YTDBGraphQueryBuilder {
 
   private final boolean vertexStep;
-  private final List<String> classes = new ArrayList<>();
+
+  // we maintain a two-level hierarchy of the requested classes:
+  // the outer level is for each hasLabel step, the inner level is for each requested
+  // class/label within hasLabel step.
+  // all labels within a single step are combined using UNION semantics, e.g. hasLabel("A", "B")
+  // will match all vertices with label A or B. hasLabel steps themselves are combined using
+  // INTERSECT semantics, e.g. hasLabel("A").hasLabel("B") matches all vertices with both labels
+  // A and B. Note, that this only makes sense when A and B have a parent-child relationship, i.e.
+  // A is a subclass of B or B is a subclass of A. Otherwise, the result will be empty.
+  private final Set<Set<String>> requestedClasses = new HashSet<>();
+
   private final List<Param> params = new ArrayList<>();
 
   public YTDBGraphQueryBuilder(boolean vertexStep, List<HasContainer> conditions) {
@@ -38,9 +53,14 @@ public class YTDBGraphQueryBuilder {
       }
       final var value = condition.getValue();
       if (value instanceof List<?> list) {
-        list.forEach(label -> addClass((String) label));
-      } else {
-        addClass((String) value);
+        requestedClasses.add(
+            list.stream()
+                .map(s -> (String) s)
+                .filter(StringUtils::isNotBlank)
+                .collect(Collectors.toSet())
+        );
+      } else if (StringUtils.isNotBlank((String) value)) {
+        requestedClasses.add(Set.of((String) value));
       }
       return ConditionType.LABEL;
     } else {
@@ -57,10 +77,42 @@ public class YTDBGraphQueryBuilder {
     }
   }
 
-  private void addClass(String classLabel) {
-    if (classLabel != null && !classLabel.isEmpty() && !classes.contains(classLabel)) {
-      classes.add(classLabel);
-    }
+  private List<String> buildClassList(HierarchyAnalyzer hierarchyAnalyzer) {
+
+    return requestedClasses.stream()
+        // 1. Apply "union" to each inner class set. At this point we just remove all classes whose
+        // parents are also requested.
+        .map(
+            innerClasses -> innerClasses.stream()
+                .filter(hierarchyAnalyzer::classExists) // ignoring non-existent classes
+                .filter(name ->
+                    // considering only classes who don't have parents also requested (union semantics)
+                    innerClasses.stream().noneMatch(
+                        maybeParent -> hierarchyAnalyzer.isSuperClassOf(maybeParent, name)
+                    )
+                )
+                .collect(Collectors.toSet())
+        )
+
+        // 2. Apply "intersection" to the resulting sets.
+        // Set A intersected with set B will
+        // produce a set containing elements whose parents (or themselves) are in both sets A
+        // and B. For instance, [dolphin,bird,insect] intersected with [mammal,ant] will produce
+        // [dolphin,ant]
+        .reduce(
+            (classesOne, classesTwo) ->
+                classesOne.stream().flatMap(c1 ->
+                        classesTwo.stream().flatMap(c2 ->
+                            hierarchyAnalyzer.selectChild(c1, c2).stream()
+                        )
+                    )
+                    .collect(Collectors.toSet())
+        )
+        .orElseGet(
+            () -> Set.of(vertexStep ? SchemaClass.VERTEX_CLASS_NAME : SchemaClass.EDGE_CLASS_NAME)
+        )
+        .stream()
+        .toList();
   }
 
   @Nullable
@@ -68,12 +120,9 @@ public class YTDBGraphQueryBuilder {
     var schema = session.getMetadata().getImmutableSchemaSnapshot();
     assert schema != null;
 
-    final var classList =
-        classes.isEmpty() ?
-            List.of(vertexStep ? SchemaClass.VERTEX_CLASS_NAME : SchemaClass.EDGE_CLASS_NAME) :
-            this.classes.stream().filter(schema::existsClass).toList();
+    final var classes = buildClassList(new HierarchyAnalyzer(schema));
 
-    if (classList.isEmpty()) {
+    if (classes.isEmpty()) {
       return new YTDBGraphEmptyQuery();
     }
 
@@ -82,18 +131,19 @@ public class YTDBGraphQueryBuilder {
     final var parameters = new HashMap<String, Object>();
     final var where = buildWhere(parameters);
 
-    if (classList.size() > 1) {
+    if (classes.size() > 1) {
       builder.append("SELECT expand($union) ");
       final var lets =
-          classList.stream()
-              .map(c -> buildLetStatement(buildSingleQuery(c, where), classList.indexOf(c)))
+          classes.stream()
+              .map(c -> buildLetStatement(buildSingleQuery(c, where), classes.indexOf(c)))
               .collect(Collectors.joining(" , "));
+
       builder.append(
-          String.format("%s , $union = UNIONALL(%s)", lets, buildVariables()));
+          String.format("%s , $union = UNIONALL(%s)", lets, buildVariables(classes.size())));
     } else {
-      builder.append(buildSingleQuery(classList.getFirst(), where));
+      builder.append(buildSingleQuery(classes.getFirst(), where));
     }
-    return new YTDBGraphQuery(builder.toString(), parameters, classList.size());
+    return new YTDBGraphQuery(builder.toString(), parameters, classes.size());
   }
 
   private String buildWhere(Map<String, Object> parameters) {
@@ -117,11 +167,11 @@ public class YTDBGraphQueryBuilder {
     return where.toString();
   }
 
-  private String buildVariables() {
+  private static String buildVariables(int count) {
     var builder = new StringBuilder();
-    for (var i = 0; i < classes.size(); i++) {
+    for (var i = 0; i < count; i++) {
       builder.append(String.format("$q%d", i));
-      if (i < classes.size() - 1) {
+      if (i < count - 1) {
         builder.append(",");
       }
     }
@@ -202,6 +252,60 @@ public class YTDBGraphQueryBuilder {
       return T.fromString(key) == T.label;
     } catch (IllegalArgumentException e) {
       return false;
+    }
+  }
+
+  private static class HierarchyAnalyzer {
+
+    private final ImmutableSchema schema;
+    private final Map<String, Set<String>> superClassesCache = new HashMap<>();
+
+    private HierarchyAnalyzer(ImmutableSchema schema) {
+      this.schema = schema;
+    }
+
+    public boolean classExists(String name) {
+      return schema.existsClass(name);
+    }
+
+    /// Return true if `superClass` is a super class of `childClass`.
+    public boolean isSuperClassOf(String superClass, String childClass) {
+      return getSuperClassesFor(childClass).contains(superClass);
+    }
+
+    /// Select the child class of the two provided classes. If classOne and classTwo are the same
+    /// class, then just return this class. If the two provided classes have a parent-child
+    /// relationship, then return the child class. Return empty optional otherwise.
+    public Optional<String> selectChild(String classOne, String classTwo) {
+      if (classOne.equals(classTwo)) {
+        return Optional.of(classOne);
+      } else if (isSuperClassOf(classOne, classTwo)) {
+        return Optional.of(classTwo);
+      } else if (isSuperClassOf(classTwo, classOne)) {
+        return Optional.of(classOne);
+      } else {
+        return Optional.empty();
+      }
+    }
+
+    private Set<String> getSuperClassesFor(String name) {
+      final var cached = superClassesCache.get(name);
+      if (cached != null) {
+        return cached;
+      }
+
+      final var clazz = schema.getClass(name);
+      final Set<String> superClasses;
+      if (clazz == null) {
+        superClasses = Set.of();
+      } else {
+        superClasses = clazz.getAllSuperClasses().stream()
+            .map(SchemaClass::getName)
+            .collect(Collectors.toSet());
+      }
+
+      superClassesCache.put(name, superClasses);
+      return superClasses;
     }
   }
 }


### PR DESCRIPTION
This PR adds correct handling of multiple hasLabel steps in one Gremlin query. Previously we treated all labels from all hasLabel steps in the same way, as a list of classes that had to be loaded together in a single query. So for instance, `g.V().hasLabel("A", "B").hasLabel("C", "D")` was interpreted as select from four classes A, B, C and D. This is obviously wrong because:
1) If A is a sub-class of B, then `hasLabel("A", "B")` is equivalent to `hasLabel("B")`. Our current implementation didn't have this logic and resulted in returning instances of A, followed by instances of B, causing duplicate results.
2) `hasLabel("A").hasLabel("B")` must be handled as intersection of A and B. This obviously makes sense only if A and B have an "is subclass of" relation, or they are equal.

This change addressed these problems and provides a fix.